### PR TITLE
Bug/data fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,172 @@
+# Oku
+
+A terminal companion for [Hardcover](https://hardcover.app). Track what you're reading, update your progress, and manage your shelves -- all without leaving the terminal.
+
+Oku gives you two ways to work:
+
+- **CLI** -- scriptable commands for quick actions and automation
+- **TUI dashboard** -- a full interactive view that launches by default
+
+## What's Working
+
+Everything you need for day-to-day use is in place:
+
+- All CLI commands
+- Interactive TUI dashboard (`oku` or `oku tui`)
+- Local SQLite cache with stale-refresh and pruning
+- Hardcover API integration with auth, throttling, timeouts, and retries
+
+## Getting Started
+
+### Prerequisites
+
+- Go (`go 1.25.7` or compatible)
+- A [Hardcover](https://hardcover.app) API token
+- macOS keychain support (via `go-keyring`), or set `HARDCOVER_TOKEN` in your environment
+
+### Build and Run
+
+```bash
+go build -o oku ./cmd/oku
+
+# Store your token in the system keychain
+./oku auth set-token
+
+# Pull your library into the local cache
+./oku sync
+
+# Open the dashboard
+./oku
+```
+
+Prefer environment variables? That works too:
+
+```bash
+export HARDCOVER_TOKEN="your_token"
+```
+
+Token lookup order:
+1. `HARDCOVER_TOKEN` environment variable
+2. System keychain (`service=oku`, `account=hardcover`)
+
+## Commands
+
+```text
+oku active                                    Show the active book
+oku auth set-token                            Store your API token
+oku config edit                               Open config in your editor
+oku config show                               Print current config
+oku list <reading|oku|finished|dnf> [--refresh]
+oku now [--refresh]                           What are you reading right now?
+oku search <query> [--limit N]                Search Hardcover
+oku set-active --book <id>                    Set a book as your current read
+oku open                                      Open the active book on Hardcover
+oku update --page <N|+N|-N> [--book <id>]     Update page progress
+oku status <reading|oku|finished|dnf> [--book <id>]
+oku sync                                      Refresh the local cache
+oku tui                                       Launch the dashboard
+```
+
+There are shortcuts for listing shelves:
+
+```bash
+oku reading    # currently reading
+oku oku        # want to read
+oku finished   # done
+oku dnf        # did not finish
+```
+
+Add `--json` to any CLI command for machine-readable output.
+
+Exit codes: `0` success, `1` user/app error, `2` network/transient failure.
+
+## TUI Dashboard
+
+Just run `oku` in a terminal (or `oku tui` explicitly).
+
+The dashboard has two panes -- **Reading** on the left, **Oku** on the right -- with book details along the bottom.
+
+### Keybindings
+
+**Library view:**
+
+| Key | Action |
+|-----|--------|
+| `Tab` / arrows | Switch pane |
+| `/` | Search Hardcover |
+| `a` | Set selected book as active |
+| `u` | Update page progress |
+| `g` `w` `f` `d` | Move to Reading / Oku / Finished / DNF |
+| `r` | Refresh from API |
+| `s` | Sync all statuses |
+| `q` | Quit |
+
+**Search mode:**
+
+| Key | Action |
+|-----|--------|
+| Type + `Enter` | Search |
+| `Enter` on result | Add to Reading and set active |
+| `a` | Set active from result |
+| `g` `w` `f` `d` | Assign status to result |
+| `Esc` | Back to library |
+
+## How Caching Works
+
+Oku tries to be a good API citizen. It caches aggressively and only hits Hardcover when it needs to:
+
+- **Cache-first** for all status lists
+- **Auto-refresh** when the cache is empty or older than **6 hours**
+- **Manual refresh** with `--refresh` on any list command, or `oku sync` for everything
+- **Clean replacement** on sync -- no stale leftovers
+- **Orphan pruning** -- cached books not referenced by any list are cleaned up after 30 days
+
+Under the hood, the API client talks to `https://api.hardcover.app/v1/graphql` with a ~1 req/sec throttle, 30s timeout, and automatic retries on transient errors (`429`, `5xx`, deadline exceeded). User cancellations are respected and not retried.
+
+## Configuration
+
+Config lives at `~/.config/oku/config.toml` (or `$XDG_CONFIG_HOME/oku/config.toml`).
+
+```toml
+editor = "nvim"
+use_fzf = false
+default_list = "reading"
+```
+
+Data and cache are stored under `~/.local/share/oku/` (or `$XDG_DATA_HOME/oku/`).
+
+## Architecture
+
+For anyone poking around the code:
+
+```
+cmd/oku/          Entrypoint
+internal/
+  cli/            Cobra commands + TUI
+  app/            Business logic, orchestration
+  api/            Hardcover GraphQL client
+  store/          SQLite cache and state
+  auth/           Token resolution + keychain
+  config/         Config loading and XDG paths
+  model/          Domain types, statuses, page parsing
+  picker/         Interactive list picker (fzf-style)
+```
+
+The flow is straightforward: CLI/TUI -> `app` -> `store` + `api`. The app layer owns the logic, the store owns the cache, and the API client handles Hardcover.
+
+## Development
+
+```bash
+go test ./...
+go vet ./...
+go build ./cmd/oku
+```
+
+Smoke test checklist:
+
+1. `oku auth set-token`
+2. `oku sync`
+3. `oku search "east of eden"`
+4. `oku tui`
+5. `oku update --page 50`
+6. Check your progress on [hardcover.app](https://hardcover.app) to confirm it synced

--- a/go.mod
+++ b/go.mod
@@ -3,19 +3,23 @@ module github.com/Kameleon21/oku
 go 1.25.7
 
 require (
+	github.com/BurntSushi/toml v1.6.0
+	github.com/charmbracelet/bubbles v0.21.1
+	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/machinebox/graphql v0.2.2
+	github.com/spf13/cobra v1.10.2
+	github.com/zalando/go-keyring v0.2.6
+	modernc.org/sqlite v1.44.3
+)
+
+require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect
-	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/catppuccin/go v0.3.0 // indirect
-	github.com/charmbracelet/bubbles v0.21.1 // indirect
-	github.com/charmbracelet/bubbletea v1.3.10 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/huh v0.8.0 // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.5 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
-	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
@@ -27,11 +31,10 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
-	github.com/machinebox/graphql v0.2.2 // indirect
+	github.com/matryer/is v1.4.1 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
-	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
@@ -39,15 +42,13 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	github.com/zalando/go-keyring v0.2.6 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
-	modernc.org/sqlite v1.44.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
+github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
+github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.21.1 h1:nj0decPiixaZeL9diI4uzzQTkkz1kYY8+jgzCZXSmW0=
 github.com/charmbracelet/bubbles v0.21.1/go.mod h1:HHvIYRCpbkCJw2yo0vNX1O5loCwSr9/mWS8GYSg50Sk=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -131,7 +131,11 @@ func isRetryable(err error) bool {
 		return false
 	}
 
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+	// User-initiated cancellation should not be retried.
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
 
@@ -149,7 +153,11 @@ func isNetworkish(err error) bool {
 		return false
 	}
 
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+	// Cancellation is intentional and should not be classified as network failure.
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -2,6 +2,12 @@ package api
 
 import (
 	"context"
+	"errors"
+	"net"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -9,6 +15,13 @@ import (
 )
 
 const endpoint = "https://api.hardcover.app/v1/graphql"
+
+const (
+	requestTimeout = 30 * time.Second
+	maxRetries     = 3
+)
+
+var statusCodeRe = regexp.MustCompile(`status code:\s*(\d{3})`)
 
 // Client wraps the machinebox/graphql client with authentication and rate limiting.
 type Client struct {
@@ -21,21 +34,75 @@ type Client struct {
 	lastReq time.Time
 }
 
+// NetworkError marks transient request failures (timeouts, 429, 5xx, transport errors).
+// The CLI maps these to exit code 2.
+type NetworkError struct {
+	Err error
+}
+
+func (e *NetworkError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *NetworkError) Unwrap() error {
+	return e.Err
+}
+
+// IsNetworkError reports whether an error should map to network/API exit code 2.
+func IsNetworkError(err error) bool {
+	var netErr *NetworkError
+	return errors.As(err, &netErr)
+}
+
 // NewClient creates a new Hardcover API client with the given auth token.
 func NewClient(token string) *Client {
+	httpClient := &http.Client{Timeout: requestTimeout}
 	return &Client{
-		gql:   graphql.NewClient(endpoint),
+		gql:   graphql.NewClient(endpoint, graphql.WithHTTPClient(httpClient)),
 		token: token,
 	}
 }
 
 // do executes a GraphQL request with auth header and rate limiting.
 func (c *Client) do(ctx context.Context, req *graphql.Request, resp interface{}) error {
-	c.throttle()
+	ctx, cancel := withRequestTimeout(ctx)
+	defer cancel()
 
 	req.Header.Set("authorization", c.token)
 
-	return c.gql.Run(ctx, req, resp)
+	var lastErr error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		c.throttle()
+
+		err := c.gql.Run(ctx, req, resp)
+		if err == nil {
+			return nil
+		}
+
+		if !isRetryable(err) {
+			if isNetworkish(err) {
+				return &NetworkError{Err: err}
+			}
+			return err
+		}
+
+		lastErr = err
+		if attempt == maxRetries {
+			break
+		}
+
+		backoff := time.Duration(attempt*attempt) * 200 * time.Millisecond
+		select {
+		case <-ctx.Done():
+			return &NetworkError{Err: ctx.Err()}
+		case <-time.After(backoff):
+		}
+	}
+
+	if lastErr == nil {
+		lastErr = context.DeadlineExceeded
+	}
+	return &NetworkError{Err: lastErr}
 }
 
 // throttle ensures at least 1 second between requests to respect the 60 req/min rate limit.
@@ -50,4 +117,65 @@ func (c *Client) throttle() {
 		}
 	}
 	c.lastReq = time.Now()
+}
+
+func withRequestTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, requestTimeout)
+}
+
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	status := extractHTTPStatus(err)
+	return status == http.StatusTooManyRequests || status >= http.StatusInternalServerError
+}
+
+func isNetworkish(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	status := extractHTTPStatus(err)
+	return status == http.StatusTooManyRequests || status == http.StatusRequestTimeout || status >= http.StatusInternalServerError
+}
+
+func extractHTTPStatus(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	msg := err.Error()
+	match := statusCodeRe.FindStringSubmatch(strings.ToLower(msg))
+	if len(match) != 2 {
+		return 0
+	}
+
+	code, convErr := strconv.Atoi(match[1])
+	if convErr != nil {
+		return 0
+	}
+	return code
 }

--- a/internal/api/mutations.go
+++ b/internal/api/mutations.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/machinebox/graphql"
 )
@@ -85,13 +86,49 @@ func (c *Client) UpdateReadProgress(ctx context.Context, userBookReadID int, pro
 	return nil
 }
 
+// InsertUserBookRead creates a new reading progress entry for the given user book.
+func (c *Client) InsertUserBookRead(ctx context.Context, userBookID int, progressPages int) (*APIUserBookRead, error) {
+	startedAt := time.Now().UTC().Format("2006-01-02")
+	q := fmt.Sprintf(`mutation {
+  insert_user_book_read(
+    user_book_id: %d,
+    user_book_read: { progress_pages: %d, started_at: "%s" }
+  ) {
+    id
+    error
+    user_book_read {
+      id
+      progress_pages
+      started_at
+      finished_at
+    }
+  }
+}`, userBookID, progressPages, startedAt)
+
+	req := graphql.NewRequest(q)
+
+	var resp InsertUserBookReadResponse
+	if err := c.do(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("InsertUserBookRead: %w", err)
+	}
+
+	r := resp.InsertUserBookRead
+	if r.Error != nil {
+		return nil, fmt.Errorf("InsertUserBookRead: API error: %s", *r.Error)
+	}
+	if r.UserBookRead == nil {
+		return nil, fmt.Errorf("InsertUserBookRead: no user_book_read returned")
+	}
+
+	return r.UserBookRead, nil
+}
+
 // UpsertUserBookReads creates or updates a reading progress entry for the given user book.
 func (c *Client) UpsertUserBookReads(ctx context.Context, userBookID int, progressPages int) error {
 	q := fmt.Sprintf(`mutation {
   upsert_user_book_reads(user_book_id: %d, datesRead: [{ progress_pages: %d }]) {
-    user_book_reads {
-      id
-    }
+    error
+    user_book_id
   }
 }`, userBookID, progressPages)
 
@@ -100,6 +137,9 @@ func (c *Client) UpsertUserBookReads(ctx context.Context, userBookID int, progre
 	var resp UpsertUserBookReadsResponse
 	if err := c.do(ctx, req, &resp); err != nil {
 		return fmt.Errorf("UpsertUserBookReads: %w", err)
+	}
+	if resp.UpsertUserBookReads.Error != nil {
+		return fmt.Errorf("UpsertUserBookReads: API error: %s", *resp.UpsertUserBookReads.Error)
 	}
 
 	return nil

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -32,7 +32,7 @@ func (c *Client) ListUserBooks(ctx context.Context, statusID int) ([]APIUserBook
     user_books(where: { status_id: { _eq: %d } }) {
       id
       status_id
-      user_book_reads {
+      user_book_reads(order_by: { id: desc }, limit: 1) {
         id
         progress_pages
         started_at
@@ -97,10 +97,10 @@ func (c *Client) SearchBooks(ctx context.Context, query string, perPage int) ([]
 	for _, hit := range tsResults.Hits {
 		doc := hit.Document
 		sr := model.SearchResult{
-			ID:      doc.ID,
+			ID:      int(doc.ID),
 			Title:   doc.Title,
 			Authors: doc.AuthorNames,
-			Pages:   doc.Pages,
+			Pages:   int(doc.Pages),
 			Slug:    doc.Slug,
 		}
 		if doc.Image != nil {

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -18,8 +18,11 @@ func (c *Client) GetMe(ctx context.Context) (int, string, error) {
 	if err := c.do(ctx, req, &resp); err != nil {
 		return 0, "", fmt.Errorf("GetMe: %w", err)
 	}
+	if len(resp.Me) == 0 {
+		return 0, "", fmt.Errorf("GetMe: empty response")
+	}
 
-	return resp.Me.ID, resp.Me.Username, nil
+	return resp.Me[0].ID, resp.Me[0].Username, nil
 }
 
 // ListUserBooks returns the user's books filtered by status ID.
@@ -59,8 +62,11 @@ func (c *Client) ListUserBooks(ctx context.Context, statusID int) ([]APIUserBook
 	if err := c.do(ctx, req, &resp); err != nil {
 		return nil, fmt.Errorf("ListUserBooks: %w", err)
 	}
+	if len(resp.Me) == 0 {
+		return nil, nil
+	}
 
-	return resp.Me.UserBooks, nil
+	return resp.Me[0].UserBooks, nil
 }
 
 // SearchBooks searches for books by query string and returns parsed results.

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -2,19 +2,21 @@ package api
 
 import "encoding/json"
 
+// MeUser represents a single user entry from the me query.
+type MeUser struct {
+	ID        int           `json:"id"`
+	Username  string        `json:"username"`
+	UserBooks []APIUserBook `json:"user_books"`
+}
+
 // MeResponse is the response shape for the me query.
 type MeResponse struct {
-	Me struct {
-		ID       int    `json:"id"`
-		Username string `json:"username"`
-	} `json:"me"`
+	Me []MeUser `json:"me"`
 }
 
 // UserBooksResponse is the response shape for listing user books.
 type UserBooksResponse struct {
-	Me struct {
-		UserBooks []APIUserBook `json:"user_books"`
-	} `json:"me"`
+	Me []MeUser `json:"me"`
 }
 
 // APIUserBook represents a user-book relationship from the API.

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1,6 +1,11 @@
 package api
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 // MeUser represents a single user entry from the me query.
 type MeUser struct {
@@ -74,17 +79,54 @@ type TypesenseResults struct {
 
 // TypesenseBookDoc represents a book document from Typesense search.
 type TypesenseBookDoc struct {
-	ID          int              `json:"id"`
-	Title       string           `json:"title"`
-	AuthorNames []string         `json:"author_names"`
-	Pages       int              `json:"pages"`
-	Slug        string           `json:"slug"`
-	Image       *TypesenseImage  `json:"image"`
+	ID          FlexibleInt     `json:"id"`
+	Title       string          `json:"title"`
+	AuthorNames []string        `json:"author_names"`
+	Pages       FlexibleInt     `json:"pages"`
+	Slug        string          `json:"slug"`
+	Image       *TypesenseImage `json:"image"`
 }
 
 // TypesenseImage represents an image in Typesense search results.
 type TypesenseImage struct {
 	URL string `json:"url"`
+}
+
+// FlexibleInt handles APIs that sometimes return a number and sometimes a quoted number.
+type FlexibleInt int
+
+func (v *FlexibleInt) UnmarshalJSON(data []byte) error {
+	s := strings.TrimSpace(string(data))
+	if s == "" || s == "null" {
+		*v = 0
+		return nil
+	}
+
+	// Quoted number: "123"
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		unquoted, err := strconv.Unquote(s)
+		if err != nil {
+			return fmt.Errorf("unquote number %q: %w", s, err)
+		}
+		if unquoted == "" {
+			*v = 0
+			return nil
+		}
+		n, err := strconv.Atoi(unquoted)
+		if err != nil {
+			return fmt.Errorf("parse quoted number %q: %w", unquoted, err)
+		}
+		*v = FlexibleInt(n)
+		return nil
+	}
+
+	// Raw number: 123
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return fmt.Errorf("parse number %q: %w", s, err)
+	}
+	*v = FlexibleInt(n)
+	return nil
 }
 
 // InsertUserBookResponse is the response shape for inserting a user book.
@@ -114,11 +156,19 @@ type UpdateUserBookReadResponse struct {
 	} `json:"update_user_book_read"`
 }
 
+// InsertUserBookReadResponse is the response shape for inserting a user book read.
+type InsertUserBookReadResponse struct {
+	InsertUserBookRead struct {
+		ID           *int             `json:"id"`
+		Error        *string          `json:"error"`
+		UserBookRead *APIUserBookRead `json:"user_book_read"`
+	} `json:"insert_user_book_read"`
+}
+
 // UpsertUserBookReadsResponse is the response shape for upserting user book reads.
 type UpsertUserBookReadsResponse struct {
 	UpsertUserBookReads struct {
-		UserBookReads []struct {
-			ID int `json:"id"`
-		} `json:"user_book_reads"`
+		Error      *string `json:"error"`
+		UserBookID *int    `json:"user_book_id"`
 	} `json:"upsert_user_book_reads"`
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -39,19 +39,35 @@ func (a *App) ValidateToken(ctx context.Context) (int, string, error) {
 }
 
 // GetActiveBookID returns the active book ID from local state.
+// If no active book is explicitly set, it falls back to the user's
+// currently-reading books from the cache — auto-selecting if there's exactly one.
 func (a *App) GetActiveBookID() (int, error) {
 	val, err := a.Store.GetState("active_book_id")
 	if err != nil {
 		return 0, err
 	}
-	if val == "" {
-		return 0, fmt.Errorf("no active book set. Use: oku set-active --book <id> or oku open")
+	if val != "" {
+		id, err := strconv.Atoi(val)
+		if err != nil {
+			return 0, fmt.Errorf("invalid active book ID: %s", val)
+		}
+		return id, nil
 	}
-	id, err := strconv.Atoi(val)
+
+	// No explicit active book — try to auto-detect from currently reading.
+	books, err := a.Store.ListUserBooks(model.StatusCurrentlyReading)
 	if err != nil {
-		return 0, fmt.Errorf("invalid active book ID: %s", val)
+		return 0, err
 	}
-	return id, nil
+	if len(books) == 1 {
+		// Auto-set when there's exactly one currently-reading book.
+		_ = a.SetActiveBook(books[0].BookID)
+		return books[0].BookID, nil
+	}
+	if len(books) > 1 {
+		return 0, fmt.Errorf("multiple books currently reading. Use: oku open")
+	}
+	return 0, fmt.Errorf("no active book set. Use: oku set-active --book <id> or oku open")
 }
 
 // SetActiveBook sets the active book by book ID.

--- a/internal/app/list.go
+++ b/internal/app/list.go
@@ -2,10 +2,13 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/Kameleon21/oku/internal/model"
 )
+
+const cacheStaleAfter = 6 * time.Hour
 
 // ListBooks returns user books for the given status.
 // Serves from cache by default; if refresh is true, fetches from API first.
@@ -21,21 +24,51 @@ func (a *App) ListBooks(ctx context.Context, status model.Status, refresh bool) 
 		return nil, err
 	}
 
-	// If cache is empty and we haven't refreshed yet, try fetching.
-	if len(books) == 0 && !refresh {
-		if err := a.syncStatus(ctx, status); err != nil {
+	// Refresh when cache is empty or stale.
+	if !refresh {
+		stale, err := a.isStatusCacheStale(status)
+		if err != nil {
 			return nil, err
 		}
-		books, err = a.Store.ListUserBooks(status)
+		if len(books) == 0 || stale {
+			if err := a.syncStatus(ctx, status); err != nil {
+				return nil, err
+			}
+			books, err = a.Store.ListUserBooks(status)
+		}
 	}
 
 	return books, err
 }
 
-// syncStatus fetches books for a status from the API and caches them.
+func (a *App) isStatusCacheStale(status model.Status) (bool, error) {
+	val, err := a.Store.GetState(syncStateKey(status))
+	if err != nil {
+		return true, err
+	}
+	if val == "" {
+		return true, nil
+	}
+	t, err := time.Parse(time.RFC3339, val)
+	if err != nil {
+		return true, nil
+	}
+	return time.Since(t) > cacheStaleAfter, nil
+}
+
+func syncStateKey(status model.Status) string {
+	return fmt.Sprintf("last_sync_status_%d", int(status))
+}
+
+// syncStatus fetches books for a status from the API and replaces cached rows for that status.
 func (a *App) syncStatus(ctx context.Context, status model.Status) error {
 	apiBooks, err := a.API.ListUserBooks(ctx, int(status))
 	if err != nil {
+		return err
+	}
+
+	// Replace rows to avoid stale entries lingering in cache.
+	if err := a.Store.DeleteUserBooksByStatus(status); err != nil {
 		return err
 	}
 
@@ -51,6 +84,8 @@ func (a *App) syncStatus(ctx context.Context, status model.Status) error {
 		}
 	}
 
+	_ = a.Store.SetState(syncStateKey(status), time.Now().UTC().Format(time.RFC3339))
+	_ = a.Store.PruneOrphanBooks(30)
 	return nil
 }
 

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -22,17 +22,12 @@ func (a *App) ChangeStatus(ctx context.Context, bookID int, status model.Status)
 
 	if ub == nil {
 		// Book not in user's library yet — insert it.
-		userBookID, err := a.API.InsertUserBook(ctx, resolvedID, int(status))
+		_, err := a.API.InsertUserBook(ctx, resolvedID, int(status))
 		if err != nil {
 			return fmt.Errorf("add book to library: %w", err)
 		}
-		// Cache the new user_book.
-		newUB := model.UserBook{
-			ID:       userBookID,
-			BookID:   resolvedID,
-			StatusID: status,
-		}
-		return a.Store.UpsertUserBook(newUB)
+		// Refresh status cache so we get full book metadata from API.
+		return a.syncStatus(ctx, status)
 	}
 
 	// Update existing user_book status.

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/Kameleon21/oku/internal/model"
 )
@@ -25,22 +26,50 @@ func (a *App) UpdateProgress(ctx context.Context, bookID int, pageUpdate model.P
 
 	// Get current page from latest read.
 	currentPage := 0
-	latestRead, _ := a.Store.GetLatestRead(ub.ID)
+	latestRead, err := a.Store.GetLatestRead(ub.ID)
+	if err != nil {
+		return 0, err
+	}
 	if latestRead != nil {
 		currentPage = latestRead.ProgressPages
 	}
 
 	newPage := pageUpdate.Resolve(currentPage, ub.Book.Pages)
 
-	// Update via API using upsert.
-	if err := a.API.UpsertUserBookReads(ctx, ub.ID, newPage); err != nil {
+	// Update an existing read entry when available, otherwise create one.
+	if latestRead != nil && latestRead.ID > 0 {
+		if err := a.API.UpdateReadProgress(ctx, latestRead.ID, newPage); err != nil {
+			return 0, fmt.Errorf("update progress: %w", err)
+		}
+		latestRead.ProgressPages = newPage
+		if err := a.Store.UpsertUserBookRead(*latestRead); err != nil {
+			return 0, err
+		}
+		return newPage, nil
+	}
+
+	read, err := a.API.InsertUserBookRead(ctx, ub.ID, newPage)
+	if err != nil {
 		return 0, fmt.Errorf("update progress: %w", err)
 	}
 
-	// Update local cache.
-	if latestRead != nil {
-		latestRead.ProgressPages = newPage
-		_ = a.Store.UpsertUserBookRead(*latestRead)
+	newRead := model.UserBookRead{
+		ID:            read.ID,
+		UserBookID:    ub.ID,
+		ProgressPages: read.ProgressPages,
+	}
+	if read.StartedAt != nil {
+		if t, parseErr := time.Parse("2006-01-02", *read.StartedAt); parseErr == nil {
+			newRead.StartedAt = &t
+		}
+	}
+	if read.FinishedAt != nil {
+		if t, parseErr := time.Parse("2006-01-02", *read.FinishedAt); parseErr == nil {
+			newRead.FinishedAt = &t
+		}
+	}
+	if err := a.Store.UpsertUserBookRead(newRead); err != nil {
+		return 0, err
 	}
 
 	return newPage, nil

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -20,7 +20,15 @@ func newRootCmd(version string) *cobra.Command {
 		Use:     "oku",
 		Short:   "A fast CLI for Hardcover",
 		Version: version,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !isInteractiveTerminal(os.Stdin) || !isInteractiveTerminal(os.Stdout) {
+				return cmd.Help()
+			}
+			return runDashboard()
+		},
 	}
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
 
 	cmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
 
@@ -35,6 +43,7 @@ func newRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(newActiveCmd())
 	cmd.AddCommand(newSetActiveCmd())
 	cmd.AddCommand(newOpenCmd())
+	cmd.AddCommand(newTUICmd())
 	cmd.AddCommand(newUpdateCmd())
 	cmd.AddCommand(newStatusCmd())
 	cmd.AddCommand(newSyncCmd())
@@ -52,6 +61,10 @@ func newRootCmd(version string) *cobra.Command {
 func Execute(version string) int {
 	cmd := newRootCmd(version)
 	if err := cmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		if api.IsNetworkError(err) {
+			return 2
+		}
 		return 1
 	}
 	return 0
@@ -82,12 +95,15 @@ func initApp() (*app.App, error) {
 	return app.New(client, db, cfg), nil
 }
 
-// exitErr prints an error and returns exit code 1.
-func exitErr(cmd *cobra.Command, err error) {
-	fmt.Fprintln(os.Stderr, "Error:", err)
-}
-
 // ctx returns a background context.
 func ctx() context.Context {
 	return context.Background()
+}
+
+func isInteractiveTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
 }

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -1,0 +1,780 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Kameleon21/oku/internal/app"
+	"github.com/Kameleon21/oku/internal/model"
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+)
+
+type viewMode int
+
+const (
+	modeLibrary viewMode = iota
+	modeSearch
+	modeUpdatePage
+)
+
+type focusPanel int
+
+const (
+	focusReading focusPanel = iota
+	focusOku
+	focusSearchInput
+	focusSearchResults
+)
+
+var (
+	panelFocusedStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("212"))
+	panelStyle        = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("239"))
+	headStyle         = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
+	dimStyleTUI       = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	infoStyleTUI      = lipgloss.NewStyle().Foreground(lipgloss.Color("114"))
+	errorStyleTUI     = lipgloss.NewStyle().Foreground(lipgloss.Color("203")).Bold(true)
+)
+
+type userBookItem struct {
+	book   model.UserBook
+	active bool
+}
+
+func (i userBookItem) Title() string {
+	marker := "  "
+	if i.active {
+		marker = "* "
+	}
+	return marker + i.book.Book.Title
+}
+
+func (i userBookItem) Description() string {
+	author := i.book.Book.AuthorString()
+	if author == "" {
+		author = "Unknown author"
+	}
+	return fmt.Sprintf("%s | %s", author, i.book.Progress())
+}
+
+func (i userBookItem) FilterValue() string {
+	return i.book.Book.Title + " " + i.book.Book.AuthorString()
+}
+
+type searchResultItem struct {
+	result model.SearchResult
+}
+
+func (i searchResultItem) Title() string {
+	if i.result.Pages > 0 {
+		return fmt.Sprintf("%s (%d pages)", i.result.Title, i.result.Pages)
+	}
+	return i.result.Title
+}
+
+func (i searchResultItem) Description() string {
+	author := strings.Join(i.result.Authors, ", ")
+	if author == "" {
+		author = "Unknown author"
+	}
+	return fmt.Sprintf("%s | ID: %d", author, i.result.ID)
+}
+
+func (i searchResultItem) FilterValue() string {
+	return i.result.Title + " " + strings.Join(i.result.Authors, " ")
+}
+
+type libraryLoadedMsg struct {
+	reading []model.UserBook
+	oku     []model.UserBook
+	err     error
+}
+
+type activeLoadedMsg struct {
+	id int
+}
+
+type searchLoadedMsg struct {
+	results []model.SearchResult
+	query   string
+	err     error
+}
+
+type opDoneMsg struct {
+	info     string
+	err      error
+	reload   bool
+	activeID int
+}
+
+type dashboardModel struct {
+	app *app.App
+
+	mode    viewMode
+	focus   focusPanel
+	loaded  bool
+	loading bool
+
+	width  int
+	height int
+
+	readingList list.Model
+	okuList     list.Model
+	searchList  list.Model
+	searchInput textinput.Model
+	pageInput   textinput.Model
+
+	readingBooks []model.UserBook
+	okuBooks     []model.UserBook
+
+	activeID      int
+	pendingBookID int
+
+	lastQuery string
+	infoMsg   string
+	errMsg    string
+}
+
+func newDashboardModel(a *app.App) dashboardModel {
+	delegate := list.NewDefaultDelegate()
+	delegate.ShowDescription = true
+
+	newList := func(title string) list.Model {
+		l := list.New(nil, delegate, 40, 12)
+		l.Title = title
+		l.SetShowStatusBar(false)
+		l.SetFilteringEnabled(true)
+		l.DisableQuitKeybindings()
+		return l
+	}
+
+	searchIn := textinput.New()
+	searchIn.Placeholder = "Search books..."
+	searchIn.CharLimit = 120
+
+	pageIn := textinput.New()
+	pageIn.Placeholder = "370 or +10 or -5"
+	pageIn.CharLimit = 32
+
+	return dashboardModel{
+		app:         a,
+		mode:        modeLibrary,
+		focus:       focusReading,
+		readingList: newList("Reading"),
+		okuList:     newList("Oku"),
+		searchList:  newList("Search Results"),
+		searchInput: searchIn,
+		pageInput:   pageIn,
+	}
+}
+
+func (m dashboardModel) Init() tea.Cmd {
+	return tea.Batch(loadActiveCmd(m.app), loadLibraryCmd(m.app, false))
+}
+
+func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m.mode {
+	case modeUpdatePage:
+		return m.updatePageMode(msg)
+	case modeSearch:
+		return m.updateSearchMode(msg)
+	default:
+		return m.updateLibraryMode(msg)
+	}
+}
+
+func (m dashboardModel) updateLibraryMode(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.resize()
+		return m, nil
+	case libraryLoadedMsg:
+		m.loading = false
+		m.loaded = true
+		if msg.err != nil {
+			m.errMsg = msg.err.Error()
+			m.infoMsg = ""
+			return m, nil
+		}
+		m.readingBooks = msg.reading
+		m.okuBooks = msg.oku
+		m.refreshListItems()
+		m.errMsg = ""
+		return m, nil
+	case activeLoadedMsg:
+		m.activeID = msg.id
+		m.refreshListItems()
+		return m, nil
+	case opDoneMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.errMsg = msg.err.Error()
+			m.infoMsg = ""
+		} else {
+			m.errMsg = ""
+			m.infoMsg = msg.info
+		}
+		if msg.activeID > 0 {
+			m.activeID = msg.activeID
+			m.refreshListItems()
+		}
+		if msg.reload {
+			m.loading = true
+			return m, loadLibraryCmd(m.app, true)
+		}
+		return m, nil
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "ctrl+c":
+			return m, tea.Quit
+		case "tab", "right", "l":
+			if m.focus == focusReading {
+				m.focus = focusOku
+			} else {
+				m.focus = focusReading
+			}
+			return m, nil
+		case "shift+tab", "left", "h":
+			if m.focus == focusOku {
+				m.focus = focusReading
+			} else {
+				m.focus = focusOku
+			}
+			return m, nil
+		case "/":
+			m.mode = modeSearch
+			m.focus = focusSearchInput
+			m.searchInput.Focus()
+			m.searchInput.SetValue("")
+			m.errMsg = ""
+			return m, nil
+		case "r":
+			m.loading = true
+			return m, loadLibraryCmd(m.app, true)
+		case "s":
+			m.loading = true
+			return m, syncAllAndReloadCmd(m.app)
+		case "a":
+			if b := m.selectedLibraryBook(); b != nil {
+				m.loading = true
+				return m, setActiveCmd(m.app, b.Book.ID)
+			}
+		case "u":
+			if b := m.selectedLibraryBook(); b != nil {
+				m.mode = modeUpdatePage
+				m.pendingBookID = b.Book.ID
+				m.pageInput.SetValue("")
+				m.pageInput.Placeholder = fmt.Sprintf("Update %s", b.Book.Title)
+				m.pageInput.Focus()
+				return m, nil
+			}
+		case "g":
+			return m.changeSelectedLibraryStatus(model.StatusCurrentlyReading)
+		case "w":
+			return m.changeSelectedLibraryStatus(model.StatusWantToRead)
+		case "f":
+			return m.changeSelectedLibraryStatus(model.StatusRead)
+		case "d":
+			return m.changeSelectedLibraryStatus(model.StatusDidNotFinish)
+		}
+	}
+
+	var cmd tea.Cmd
+	if m.focus == focusReading {
+		m.readingList, cmd = m.readingList.Update(msg)
+	} else {
+		m.okuList, cmd = m.okuList.Update(msg)
+	}
+	return m, cmd
+}
+
+func (m dashboardModel) updateSearchMode(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.resize()
+		return m, nil
+	case searchLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.errMsg = msg.err.Error()
+			m.infoMsg = ""
+			return m, nil
+		}
+		m.lastQuery = msg.query
+		items := make([]list.Item, 0, len(msg.results))
+		for _, r := range msg.results {
+			items = append(items, searchResultItem{result: r})
+		}
+		m.searchList.SetItems(items)
+		m.searchList.Title = fmt.Sprintf("Search Results (%d)", len(items))
+		if len(items) > 0 {
+			m.focus = focusSearchResults
+		}
+		m.errMsg = ""
+		m.infoMsg = fmt.Sprintf("Loaded %d results", len(items))
+		return m, nil
+	case opDoneMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.errMsg = msg.err.Error()
+			m.infoMsg = ""
+		} else {
+			m.errMsg = ""
+			m.infoMsg = msg.info
+		}
+		if msg.activeID > 0 {
+			m.activeID = msg.activeID
+		}
+		if msg.reload {
+			// Keep search view, but refresh local library in background.
+			return m, loadLibraryCmd(m.app, true)
+		}
+		return m, nil
+	case libraryLoadedMsg:
+		// background refresh after actions in search mode
+		if msg.err == nil {
+			m.readingBooks = msg.reading
+			m.okuBooks = msg.oku
+			m.refreshListItems()
+		}
+		return m, nil
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "ctrl+c":
+			return m, tea.Quit
+		case "esc":
+			m.mode = modeLibrary
+			m.focus = focusReading
+			m.searchInput.Blur()
+			return m, nil
+		}
+
+		if m.focus == focusSearchInput {
+			switch msg.String() {
+			case "enter":
+				query := strings.TrimSpace(m.searchInput.Value())
+				if query == "" {
+					m.errMsg = "search query cannot be empty"
+					return m, nil
+				}
+				m.loading = true
+				m.errMsg = ""
+				return m, searchCmd(m.app, query)
+			case "tab", "down":
+				if len(m.searchList.Items()) > 0 {
+					m.focus = focusSearchResults
+				}
+				return m, nil
+			}
+			var cmd tea.Cmd
+			m.searchInput, cmd = m.searchInput.Update(msg)
+			return m, cmd
+		}
+
+		// focusSearchResults
+		switch msg.String() {
+		case "tab", "up":
+			m.focus = focusSearchInput
+			return m, nil
+		case "enter":
+			if r := m.selectedSearchResult(); r != nil {
+				m.loading = true
+				return m, addFromSearchCmd(m.app, r.ID, model.StatusCurrentlyReading, true)
+			}
+		case "a":
+			if r := m.selectedSearchResult(); r != nil {
+				m.loading = true
+				return m, setActiveCmd(m.app, r.ID)
+			}
+		case "g":
+			return m.changeSelectedSearchStatus(model.StatusCurrentlyReading, true)
+		case "w":
+			return m.changeSelectedSearchStatus(model.StatusWantToRead, false)
+		case "f":
+			return m.changeSelectedSearchStatus(model.StatusRead, false)
+		case "d":
+			return m.changeSelectedSearchStatus(model.StatusDidNotFinish, false)
+		}
+	}
+
+	var cmd tea.Cmd
+	if m.focus == focusSearchResults {
+		m.searchList, cmd = m.searchList.Update(msg)
+	} else {
+		m.searchInput, cmd = m.searchInput.Update(msg)
+	}
+	return m, cmd
+}
+
+func (m dashboardModel) updatePageMode(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.resize()
+		return m, nil
+	case opDoneMsg:
+		m.loading = false
+		m.mode = modeLibrary
+		m.pageInput.Blur()
+		if msg.err != nil {
+			m.errMsg = msg.err.Error()
+			m.infoMsg = ""
+		} else {
+			m.errMsg = ""
+			m.infoMsg = msg.info
+		}
+		if msg.reload {
+			m.loading = true
+			return m, loadLibraryCmd(m.app, true)
+		}
+		return m, nil
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			m.mode = modeLibrary
+			m.pageInput.Blur()
+			m.pageInput.SetValue("")
+			return m, nil
+		case "ctrl+c":
+			return m, tea.Quit
+		case "enter":
+			raw := strings.TrimSpace(m.pageInput.Value())
+			if raw == "" {
+				m.errMsg = "page value cannot be empty"
+				return m, nil
+			}
+			m.loading = true
+			return m, updateProgressCmd(m.app, m.pendingBookID, raw)
+		}
+	}
+
+	var cmd tea.Cmd
+	m.pageInput, cmd = m.pageInput.Update(msg)
+	return m, cmd
+}
+
+func (m dashboardModel) View() string {
+	if !m.loaded {
+		return "Loading dashboard..."
+	}
+
+	title := headStyle.Render("Oku Dashboard")
+	if m.loading {
+		title += "  " + dimStyleTUI.Render("Loading...")
+	}
+
+	notice := ""
+	if m.errMsg != "" {
+		notice = errorStyleTUI.Render(m.errMsg)
+	} else if m.infoMsg != "" {
+		notice = infoStyleTUI.Render(m.infoMsg)
+	} else {
+		notice = dimStyleTUI.Render("Rate-limit friendly cache: status lists auto-refresh only when stale or forced.")
+	}
+
+	if m.mode == modeSearch {
+		return title + "\n" + notice + "\n\n" + m.renderSearch() + "\n" + m.searchHelp()
+	}
+	if m.mode == modeUpdatePage {
+		return title + "\n" + notice + "\n\n" + m.renderLibrary() + "\n" + infoStyleTUI.Render("Page update: ") + m.pageInput.View() + dimStyleTUI.Render("  (Enter submit, Esc cancel)")
+	}
+	return title + "\n" + notice + "\n\n" + m.renderLibrary() + "\n" + m.libraryHelp()
+}
+
+func (m dashboardModel) renderLibrary() string {
+	left := m.readingList.View()
+	right := m.okuList.View()
+
+	leftBox := panelStyle.Render(left)
+	rightBox := panelStyle.Render(right)
+	if m.focus == focusReading {
+		leftBox = panelFocusedStyle.Render(left)
+	}
+	if m.focus == focusOku {
+		rightBox = panelFocusedStyle.Render(right)
+	}
+
+	top := lipgloss.JoinHorizontal(lipgloss.Top, leftBox, rightBox)
+	details := panelStyle.Render(m.detailsView())
+	return top + "\n" + details
+}
+
+func (m dashboardModel) renderSearch() string {
+	inputBox := panelStyle.Render(m.searchInput.View())
+	if m.focus == focusSearchInput {
+		inputBox = panelFocusedStyle.Render(m.searchInput.View())
+	}
+
+	results := m.searchList.View()
+	resultsBox := panelStyle.Render(results)
+	if m.focus == focusSearchResults {
+		resultsBox = panelFocusedStyle.Render(results)
+	}
+
+	return headStyle.Render("Search") + "\n" + inputBox + "\n" + resultsBox
+}
+
+func (m dashboardModel) detailsView() string {
+	b := m.selectedLibraryBook()
+	if b == nil {
+		return "No book selected."
+	}
+	lines := []string{
+		headStyle.Render(b.Book.Title),
+		fmt.Sprintf("Author: %s", fallback(b.Book.AuthorString(), "Unknown author")),
+		fmt.Sprintf("Progress: %s", b.Progress()),
+		fmt.Sprintf("Status: %s", b.StatusID.Label()),
+		fmt.Sprintf("Book ID: %d", b.Book.ID),
+	}
+	if b.Book.Pages > 0 {
+		lines = append(lines, fmt.Sprintf("Pages: %d", b.Book.Pages))
+	}
+	if b.Book.Slug != "" {
+		lines = append(lines, fmt.Sprintf("Slug: %s", b.Book.Slug))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m dashboardModel) libraryHelp() string {
+	return dimStyleTUI.Render("Home keys: Tab switch pane | / search | a active | u update | g/w/f/d status | r refresh | s sync | q quit")
+}
+
+func (m dashboardModel) searchHelp() string {
+	return dimStyleTUI.Render("Search keys: Enter search/add-reading | Tab switch input/results | a active | g/w/f/d status | Esc back | q quit")
+}
+
+func (m *dashboardModel) resize() {
+	totalW := max(60, m.width-2)
+	totalH := max(18, m.height-8)
+	paneW := max(28, totalW/2-1)
+	listH := max(8, totalH/2)
+
+	m.readingList.SetSize(paneW, listH)
+	m.okuList.SetSize(paneW, listH)
+	m.searchList.SetSize(totalW, max(8, totalH-4))
+}
+
+func (m *dashboardModel) refreshListItems() {
+	toItems := func(books []model.UserBook) []list.Item {
+		items := make([]list.Item, 0, len(books))
+		for _, b := range books {
+			items = append(items, userBookItem{
+				book:   b,
+				active: b.Book.ID == m.activeID,
+			})
+		}
+		return items
+	}
+	m.readingList.SetItems(toItems(m.readingBooks))
+	m.okuList.SetItems(toItems(m.okuBooks))
+	m.readingList.Title = fmt.Sprintf("Reading (%d)", len(m.readingBooks))
+	m.okuList.Title = fmt.Sprintf("Oku (%d)", len(m.okuBooks))
+}
+
+func (m dashboardModel) selectedLibraryBook() *model.UserBook {
+	var item list.Item
+	if m.focus == focusOku {
+		item = m.okuList.SelectedItem()
+	} else {
+		item = m.readingList.SelectedItem()
+	}
+	if item == nil {
+		return nil
+	}
+	ub, ok := item.(userBookItem)
+	if !ok {
+		return nil
+	}
+	book := ub.book
+	return &book
+}
+
+func (m dashboardModel) selectedSearchResult() *model.SearchResult {
+	item := m.searchList.SelectedItem()
+	if item == nil {
+		return nil
+	}
+	sr, ok := item.(searchResultItem)
+	if !ok {
+		return nil
+	}
+	r := sr.result
+	return &r
+}
+
+func (m dashboardModel) changeSelectedLibraryStatus(status model.Status) (tea.Model, tea.Cmd) {
+	b := m.selectedLibraryBook()
+	if b == nil {
+		m.errMsg = "no book selected"
+		return m, nil
+	}
+	m.loading = true
+	return m, changeStatusCmd(m.app, b.Book.ID, status)
+}
+
+func (m dashboardModel) changeSelectedSearchStatus(status model.Status, setActive bool) (tea.Model, tea.Cmd) {
+	r := m.selectedSearchResult()
+	if r == nil {
+		m.errMsg = "no search result selected"
+		return m, nil
+	}
+	m.loading = true
+	return m, addFromSearchCmd(m.app, r.ID, status, setActive)
+}
+
+func loadLibraryCmd(a *app.App, refresh bool) tea.Cmd {
+	return func() tea.Msg {
+		reading, err := a.ListBooks(ctx(), model.StatusCurrentlyReading, refresh)
+		if err != nil {
+			return libraryLoadedMsg{err: err}
+		}
+		oku, err := a.ListBooks(ctx(), model.StatusWantToRead, refresh)
+		if err != nil {
+			return libraryLoadedMsg{err: err}
+		}
+		return libraryLoadedMsg{
+			reading: reading,
+			oku:     oku,
+		}
+	}
+}
+
+func loadActiveCmd(a *app.App) tea.Cmd {
+	return func() tea.Msg {
+		id, err := a.GetActiveBookID()
+		if err != nil {
+			return activeLoadedMsg{}
+		}
+		return activeLoadedMsg{id: id}
+	}
+}
+
+func searchCmd(a *app.App, query string) tea.Cmd {
+	return func() tea.Msg {
+		results, err := a.SearchBooks(ctx(), query, 10)
+		return searchLoadedMsg{
+			results: results,
+			query:   query,
+			err:     err,
+		}
+	}
+}
+
+func setActiveCmd(a *app.App, bookID int) tea.Cmd {
+	return func() tea.Msg {
+		if err := a.SetActiveBook(bookID); err != nil {
+			return opDoneMsg{err: err}
+		}
+		return opDoneMsg{
+			info:     fmt.Sprintf("Active book set to ID %d", bookID),
+			activeID: bookID,
+		}
+	}
+}
+
+func updateProgressCmd(a *app.App, bookID int, rawPage string) tea.Cmd {
+	return func() tea.Msg {
+		p, err := model.ParsePage(rawPage)
+		if err != nil {
+			return opDoneMsg{err: err}
+		}
+		newPage, err := a.UpdateProgress(ctx(), bookID, p)
+		if err != nil {
+			return opDoneMsg{err: err}
+		}
+		return opDoneMsg{
+			info:   fmt.Sprintf("Progress updated to page %d", newPage),
+			reload: true,
+		}
+	}
+}
+
+func changeStatusCmd(a *app.App, bookID int, status model.Status) tea.Cmd {
+	return func() tea.Msg {
+		if err := a.ChangeStatus(ctx(), bookID, status); err != nil {
+			return opDoneMsg{err: err}
+		}
+		return opDoneMsg{
+			info:   fmt.Sprintf("Status changed to %s", status.Label()),
+			reload: true,
+		}
+	}
+}
+
+func addFromSearchCmd(a *app.App, bookID int, status model.Status, setActive bool) tea.Cmd {
+	return func() tea.Msg {
+		if err := a.ChangeStatus(ctx(), bookID, status); err != nil {
+			return opDoneMsg{err: err}
+		}
+		if setActive {
+			if err := a.SetActiveBook(bookID); err != nil {
+				return opDoneMsg{err: err}
+			}
+		}
+		msg := fmt.Sprintf("Added to %s", status.Label())
+		if setActive {
+			msg += " and set active"
+		}
+		return opDoneMsg{
+			info:     msg,
+			reload:   true,
+			activeID: ternaryInt(setActive, bookID, 0),
+		}
+	}
+}
+
+func syncAllAndReloadCmd(a *app.App) tea.Cmd {
+	return func() tea.Msg {
+		if err := a.SyncAll(ctx()); err != nil {
+			return opDoneMsg{err: err}
+		}
+		return opDoneMsg{
+			info:   "Sync complete",
+			reload: true,
+		}
+	}
+}
+
+func runDashboard() error {
+	a, err := initApp()
+	if err != nil {
+		return err
+	}
+	defer a.Store.Close()
+
+	p := tea.NewProgram(newDashboardModel(a), tea.WithAltScreen())
+	_, err = p.Run()
+	return err
+}
+
+func newTUICmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "tui",
+		Short: "Launch the interactive Oku dashboard",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDashboard()
+		},
+	}
+}
+
+func fallback(value, def string) string {
+	if strings.TrimSpace(value) == "" {
+		return def
+	}
+	return value
+}
+
+func ternaryInt(cond bool, a, b int) int {
+	if cond {
+		return a
+	}
+	return b
+}

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -2,7 +2,6 @@ package picker
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -121,7 +120,7 @@ func PickBook(books []model.UserBook, title string) (int, error) {
 	l.SetFilteringEnabled(true)
 
 	m := pickerModel{list: l}
-	p := tea.NewProgram(m, tea.WithOutput(io.Discard))
+	p := tea.NewProgram(m)
 
 	final, err := p.Run()
 	if err != nil {
@@ -148,7 +147,7 @@ func PickSearchResult(results []model.SearchResult, title string) (int, error) {
 	l.SetFilteringEnabled(true)
 
 	m := pickerModel{list: l}
-	p := tea.NewProgram(m, tea.WithOutput(io.Discard))
+	p := tea.NewProgram(m)
 
 	final, err := p.Run()
 	if err != nil {

--- a/internal/store/books.go
+++ b/internal/store/books.go
@@ -59,3 +59,21 @@ func splitAuthors(s string) []string {
 	}
 	return out
 }
+
+// PruneOrphanBooks removes cached books not referenced by user_books and older than maxAgeDays.
+func (s *Store) PruneOrphanBooks(maxAgeDays int) error {
+	if maxAgeDays <= 0 {
+		maxAgeDays = 30
+	}
+
+	const query = `
+DELETE FROM books
+WHERE id NOT IN (SELECT book_id FROM user_books)
+  AND updated_at < datetime('now', ?)
+`
+	age := fmt.Sprintf("-%d days", maxAgeDays)
+	if _, err := s.db.Exec(query, age); err != nil {
+		return fmt.Errorf("prune orphan books: %w", err)
+	}
+	return nil
+}

--- a/internal/store/user_books.go
+++ b/internal/store/user_books.go
@@ -161,3 +161,32 @@ LIMIT 1
 	}
 	return &r, nil
 }
+
+// DeleteUserBooksByStatus removes all user_books rows for a status and their reads.
+func (s *Store) DeleteUserBooksByStatus(status model.Status) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	const deleteReads = `
+DELETE FROM user_book_reads
+WHERE user_book_id IN (
+	SELECT id FROM user_books WHERE status_id = ?
+)
+`
+	if _, err := tx.Exec(deleteReads, int(status)); err != nil {
+		return fmt.Errorf("delete reads by status %d: %w", status, err)
+	}
+
+	const deleteBooks = `DELETE FROM user_books WHERE status_id = ?`
+	if _, err := tx.Exec(deleteBooks, int(status)); err != nil {
+		return fmt.Errorf("delete user_books status %d: %w", status, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit delete status %d: %w", status, err)
+	}
+	return nil
+}

--- a/internal/store/user_books.go
+++ b/internal/store/user_books.go
@@ -60,6 +60,10 @@ ORDER BY ub.updated_at DESC
 		if t, err := time.Parse(time.RFC3339, updatedAt); err == nil {
 			ub.UpdatedAt = t
 		}
+		// Attach latest reading progress.
+		if read, err := s.GetLatestRead(ub.ID); err == nil && read != nil {
+			ub.UserBookReads = []model.UserBookRead{*read}
+		}
 		result = append(result, ub)
 	}
 	return result, rows.Err()
@@ -91,6 +95,11 @@ WHERE ub.book_id = ?
 	ub.Book.Authors = splitAuthors(authors)
 	if t, err := time.Parse(time.RFC3339, updatedAt); err == nil {
 		ub.UpdatedAt = t
+	}
+
+	// Attach latest reading progress.
+	if read, err := s.GetLatestRead(ub.ID); err == nil && read != nil {
+		ub.UserBookReads = []model.UserBookRead{*read}
 	}
 	return &ub, nil
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed data fetching bugs by changing API response handling from object to array format and implemented robust error handling with retry logic.

## Key Changes

- **API Response Structure Fix**: Changed `me` query response from object to array (`resp.Me[0]` instead of `resp.Me`), addressing the root cause of data fetching failures
- **Retry Logic & Error Handling**: Added exponential backoff retry (3 attempts), 30s request timeout, and `NetworkError` wrapper for transient failures (exit code 2 for network issues)
- **FlexibleInt Type**: Created custom unmarshaler to handle API inconsistency where numbers are sometimes quoted strings
- **Cache Staleness**: Implemented 6-hour staleness check with delete-then-insert pattern to prevent stale cache entries
- **Progress Tracking**: Changed from upsert to explicit update/insert logic, added `InsertUserBookRead` mutation
- **Interactive Dashboard**: Added 780-line TUI with search, status management, and progress updates
- **Active Book Auto-detection**: When no active book set, auto-selects if exactly one book is currently reading
- **Query Optimization**: Limited `user_book_reads` to latest entry only (`order_by: { id: desc }, limit: 1`)

## Implementation Quality

- Proper transaction handling in `DeleteUserBooksByStatus`
- Comprehensive error checking on API error fields
- Rate limiting respected (1 req/sec throttle)
- Context timeout inheritance check in `withRequestTimeout`
- Orphan book cleanup added to prevent cache bloat

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor observations on error handling edge cases
- The PR addresses critical data fetching bugs with well-structured fixes. The API response format change from object to array is correct and handles empty responses. Retry logic and error handling are robust. Cache management uses proper transaction boundaries. One minor concern: `isRetryable` returns true for `context.Canceled`, which may retry user-initiated cancellations unnecessarily, though this is a minor UX issue rather than a bug.
- Pay close attention to `internal/api/client.go` for retry logic behavior and `internal/cli/tui.go` for the large new TUI implementation

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/api/client.go | Added retry logic with exponential backoff, request timeouts, and NetworkError wrapper for transient failures |
| internal/api/types.go | Changed `me` query response from object to array, added FlexibleInt for handling quoted/unquoted numbers from API |
| internal/app/list.go | Added 6-hour cache staleness check and delete-then-insert pattern for cache refresh to avoid stale entries |
| internal/app/update.go | Changed from upsert to explicit update/insert logic for progress tracking |
| internal/cli/tui.go | New 780-line interactive dashboard with search, status changes, progress updates |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant App
    participant API
    participant Store
    participant Cache

    Note over User,Cache: Data Fetching Flow (with new retry logic)
    
    User->>CLI: List books / Update progress
    CLI->>App: ListBooks(status, refresh)
    App->>Store: Check cache staleness
    Store-->>App: Cache stale or empty
    
    App->>Store: DeleteUserBooksByStatus(status)
    Store->>Cache: DELETE user_books WHERE status_id=X
    
    App->>API: ListUserBooks(statusID)
    Note over API: Retry up to 3 times with backoff
    API->>API: Check if retryable (429, 5xx, timeout)
    alt Network/Transient Error
        API-->>App: NetworkError (exit code 2)
    else Success
        API-->>App: []APIUserBook (me[0].user_books)
    end
    
    App->>Store: UpsertUserBook for each book
    App->>Store: UpsertUserBookRead for each read
    App->>Store: SetState(last_sync_status_X, now)
    App->>Store: PruneOrphanBooks(30 days)
    
    Store-->>App: Books cached
    App-->>CLI: Display results
    
    Note over User,Cache: Progress Update Flow (new insert/update logic)
    
    User->>CLI: Update progress (page number)
    CLI->>App: UpdateProgress(bookID, pageUpdate)
    App->>Store: GetLatestRead(userBookID)
    
    alt Latest read exists
        App->>API: UpdateReadProgress(readID, newPage)
        API-->>App: Success
        App->>Store: UpsertUserBookRead (update cache)
    else No read entry
        App->>API: InsertUserBookRead(userBookID, newPage)
        API-->>App: UserBookRead with ID
        App->>Store: UpsertUserBookRead (insert to cache)
    end
    
    App-->>CLI: New page number
    CLI-->>User: Progress updated
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->