### PR TITLE
bug: update caching

### DIFF
--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Kameleon21/oku/internal/app"
 	"github.com/Kameleon21/oku/internal/model"
@@ -20,6 +21,11 @@ const (
 	modeLibrary viewMode = iota
 	modeSearch
 	modeUpdatePage
+)
+
+const (
+	backgroundSyncWindow = 10 * time.Minute
+	backgroundCheckEvery = 1 * time.Minute
 )
 
 type focusPanel int
@@ -95,10 +101,13 @@ type searchLoadedMsg struct {
 }
 
 type opDoneMsg struct {
-	info   string
-	err    error
-	reload bool
+	info      string
+	err       error
+	reload    bool
+	markDirty bool
 }
+
+type backgroundCheckMsg struct{}
 
 type dashboardModel struct {
 	app *app.App
@@ -121,7 +130,9 @@ type dashboardModel struct {
 	readingBooks []model.UserBook
 	okuBooks     []model.UserBook
 
-	pendingBookID int
+	pendingBookID  int
+	dirty          bool
+	lastMutationAt time.Time
 
 	lastQuery string
 	infoMsg   string
@@ -209,7 +220,7 @@ func newDashboardModel(a *app.App) dashboardModel {
 }
 
 func (m dashboardModel) Init() tea.Cmd {
-	return tea.Batch(m.spin.Tick, loadLibraryCmd(m.app, false))
+	return tea.Batch(m.spin.Tick, loadLibraryCmd(m.app, false), backgroundCheckCmd())
 }
 
 func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -247,6 +258,13 @@ func (m dashboardModel) updateLibraryMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.refreshListItems()
 		m.errMsg = ""
 		return m, nil
+	case backgroundCheckMsg:
+		if m.dirty && !m.loading && time.Since(m.lastMutationAt) >= backgroundSyncWindow {
+			m.loading = true
+			m.dirty = false
+			return m, tea.Batch(loadLibraryCmd(m.app, true), backgroundCheckCmd())
+		}
+		return m, backgroundCheckCmd()
 	case opDoneMsg:
 		m.loading = false
 		if msg.err != nil {
@@ -255,10 +273,14 @@ func (m dashboardModel) updateLibraryMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.errMsg = ""
 			m.infoMsg = msg.info
+			if msg.markDirty {
+				m.dirty = true
+				m.lastMutationAt = time.Now()
+			}
 		}
 		if msg.reload {
 			m.loading = true
-			return m, loadLibraryCmd(m.app, true)
+			return m, loadLibraryCmd(m.app, false)
 		}
 		return m, nil
 	case tea.KeyMsg:
@@ -359,6 +381,13 @@ func (m dashboardModel) updateSearchMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.errMsg = ""
 		m.infoMsg = fmt.Sprintf("Loaded %d results", len(items))
 		return m, nil
+	case backgroundCheckMsg:
+		if m.dirty && !m.loading && time.Since(m.lastMutationAt) >= backgroundSyncWindow {
+			m.loading = true
+			m.dirty = false
+			return m, tea.Batch(loadLibraryCmd(m.app, true), backgroundCheckCmd())
+		}
+		return m, backgroundCheckCmd()
 	case opDoneMsg:
 		m.loading = false
 		if msg.err != nil {
@@ -367,10 +396,14 @@ func (m dashboardModel) updateSearchMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.errMsg = ""
 			m.infoMsg = msg.info
+			if msg.markDirty {
+				m.dirty = true
+				m.lastMutationAt = time.Now()
+			}
 		}
 		if msg.reload {
 			// Keep search view, but refresh local library in background.
-			return m, loadLibraryCmd(m.app, true)
+			return m, loadLibraryCmd(m.app, false)
 		}
 		return m, nil
 	case libraryLoadedMsg:
@@ -455,6 +488,13 @@ func (m dashboardModel) updatePageMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		m.resize()
 		return m, nil
+	case backgroundCheckMsg:
+		if m.dirty && !m.loading && time.Since(m.lastMutationAt) >= backgroundSyncWindow {
+			m.loading = true
+			m.dirty = false
+			return m, tea.Batch(loadLibraryCmd(m.app, true), backgroundCheckCmd())
+		}
+		return m, backgroundCheckCmd()
 	case opDoneMsg:
 		m.loading = false
 		m.mode = modeLibrary
@@ -465,10 +505,14 @@ func (m dashboardModel) updatePageMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.errMsg = ""
 			m.infoMsg = msg.info
+			if msg.markDirty {
+				m.dirty = true
+				m.lastMutationAt = time.Now()
+			}
 		}
 		if msg.reload {
 			m.loading = true
-			return m, loadLibraryCmd(m.app, true)
+			return m, loadLibraryCmd(m.app, false)
 		}
 		return m, nil
 	case tea.KeyMsg:
@@ -773,8 +817,9 @@ func updateProgressCmd(a *app.App, bookID int, rawPage string) tea.Cmd {
 			return opDoneMsg{err: err}
 		}
 		return opDoneMsg{
-			info:   fmt.Sprintf("Progress updated to page %d", newPage),
-			reload: true,
+			info:      fmt.Sprintf("Progress updated to page %d", newPage),
+			reload:    true,
+			markDirty: true,
 		}
 	}
 }
@@ -785,8 +830,9 @@ func changeStatusCmd(a *app.App, bookID int, status model.Status) tea.Cmd {
 			return opDoneMsg{err: err}
 		}
 		return opDoneMsg{
-			info:   fmt.Sprintf("Status changed to %s", status.Label()),
-			reload: true,
+			info:      fmt.Sprintf("Status changed to %s", status.Label()),
+			reload:    true,
+			markDirty: true,
 		}
 	}
 }
@@ -797,8 +843,9 @@ func addFromSearchCmd(a *app.App, bookID int, status model.Status) tea.Cmd {
 			return opDoneMsg{err: err}
 		}
 		return opDoneMsg{
-			info:   fmt.Sprintf("Added to %s", status.Label()),
-			reload: true,
+			info:      fmt.Sprintf("Added to %s", status.Label()),
+			reload:    true,
+			markDirty: true,
 		}
 	}
 }
@@ -813,6 +860,12 @@ func syncAllAndReloadCmd(a *app.App) tea.Cmd {
 			reload: true,
 		}
 	}
+}
+
+func backgroundCheckCmd() tea.Cmd {
+	return tea.Tick(backgroundCheckEvery, func(time.Time) tea.Msg {
+		return backgroundCheckMsg{}
+	})
 }
 
 func runDashboard() error {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Implemented a deferred background sync mechanism to optimize API usage. The changes replace immediate API syncs after mutations with a smart caching strategy:

- **Background sync timer**: Added a background check that runs every minute and triggers an API sync after 10 minutes of inactivity following local mutations
- **Dirty flag tracking**: Introduced `dirty` flag and `lastMutationAt` timestamp to track when local changes occur
- **Optimized reload behavior**: Changed from immediate API refresh (`refresh=true`) to cache-first approach (`refresh=false`) after mutations, since mutations already update the local cache
- **Preserves correctness**: Mutations (status changes, progress updates) still update both the API and local SQLite cache immediately, so the UI reflects changes instantly

This reduces unnecessary API calls while maintaining data consistency. Users can still force immediate sync with the 's' key, and the background sync ensures eventual consistency with the server (useful for multi-device scenarios).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with only minor considerations
- The implementation is well-designed and the caching optimization is sound. The mutations correctly update both the API and local cache, so the immediate UI refresh works correctly. The background sync provides eventual consistency. The score is 4 instead of 5 because: (1) the 10-minute delay before background sync might be surprising to users expecting immediate server sync in multi-device scenarios, and (2) there's no handling for what happens if the background sync fails (errors are not surfaced to the user)
- No files require special attention - the implementation is straightforward and follows the existing patterns in the codebase

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/cli/tui.go | Implemented deferred background sync mechanism to reduce API calls, marking mutations as dirty and syncing after 10 minutes instead of immediately |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TUI as Dashboard TUI
    participant App as App Layer
    participant Cache as SQLite Cache
    participant API as Hardcover API

    Note over TUI: User changes book status
    User->>TUI: Press 'g' (move to Reading)
    TUI->>App: changeStatusCmd(bookID, status)
    App->>API: UpdateUserBookStatus(bookID, status)
    API-->>App: Success
    App->>Cache: UpsertUserBook(status_id updated)
    App-->>TUI: opDoneMsg{reload: true, markDirty: true}
    
    Note over TUI: Update UI state
    TUI->>TUI: Set dirty=true, lastMutationAt=now()
    TUI->>App: loadLibraryCmd(refresh=false)
    App->>Cache: ListUserBooks(StatusReading)
    Cache-->>App: Books (includes newly moved book)
    App->>Cache: ListUserBooks(StatusWantToRead)
    Cache-->>App: Books (excludes moved book)
    App-->>TUI: libraryLoadedMsg
    TUI->>TUI: Update UI lists
    
    Note over TUI: Background sync after 10 minutes
    loop Every 1 minute
        TUI->>TUI: backgroundCheckMsg
        alt dirty && 10 min passed && not loading
            TUI->>App: loadLibraryCmd(refresh=true)
            App->>API: ListUserBooks (both statuses)
            API-->>App: Latest data from server
            App->>Cache: Update cache
            App-->>TUI: libraryLoadedMsg
            TUI->>TUI: Set dirty=false
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->