### PR TITLE
Feature/auther gener

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,141 +1,152 @@
 # Oku
 
-A terminal companion for [Hardcover](https://hardcover.app). Track what you're reading, update your progress, and manage your shelves -- all without leaving the terminal.
+Terminal companion for [Hardcover](https://hardcover.app): browse your shelves, search books, and update progress without leaving the terminal.
 
-Oku gives you two ways to work:
+## What You Get
 
-- **CLI** -- scriptable commands for quick actions and automation
-- **TUI dashboard** -- a full interactive view that launches by default
+- CLI for scripting and quick actions
+- Full TUI dashboard (`oku` or `oku tui`)
+- Vim-first navigation in TUI (arrow keys also work)
+- Search modes: `book`, `author`, `genre`
+- Output density modes: `compact`, `default`, `verbose`
+- Local SQLite cache with auto-refresh and manual sync
 
-## What's Working
+## Requirements
 
-Everything you need for day-to-day use is in place:
+- Go (project currently uses `go 1.25.7`)
+- Hardcover API token
+- Keychain support (recommended) or `HARDCOVER_TOKEN` env var
 
-- All CLI commands
-- Interactive TUI dashboard (`oku` or `oku tui`)
-- Local SQLite cache with stale-refresh and pruning
-- Hardcover API integration with auth, throttling, timeouts, and retries
-
-## Getting Started
-
-### Prerequisites
-
-- Go (`go 1.25.7` or compatible)
-- A [Hardcover](https://hardcover.app) API token
-- macOS keychain support (via `go-keyring`), or set `HARDCOVER_TOKEN` in your environment
-
-### Build and Run
+## Quick Start
 
 ```bash
 go build -o oku ./cmd/oku
 
-# Store your token in the system keychain
+# Save token in keychain
 ./oku auth set-token
 
-# Pull your library into the local cache
+# Pull data to local cache
 ./oku sync
 
-# Open the dashboard
+# Launch dashboard
 ./oku
 ```
 
-Prefer environment variables? That works too:
-
-```bash
-export HARDCOVER_TOKEN="your_token"
-```
-
 Token lookup order:
-1. `HARDCOVER_TOKEN` environment variable
-2. System keychain (`service=oku`, `account=hardcover`)
 
-## Commands
+1. `HARDCOVER_TOKEN`
+2. Keychain (`service=oku`, `account=hardcover`)
+
+## Core Commands
 
 ```text
-oku active                                    Show active books
-oku auth set-token                            Store your API token
-oku config edit                               Open config in your editor
-oku config show                               Print current config
+oku auth set-token
+oku config show
+oku config edit
+
 oku list <reading|oku|finished|dnf> [--refresh]
-oku now [--refresh]                           What are you reading right now?
-oku search <query> [--limit N] [--mode M]     Search Hardcover (book/author/genre)
-oku set-active --book <id>                    Add a book to your active list
-oku open                                      Pick a currently-reading book and add it to active list
-oku update --page <N|+N|-N> [--book <id>]     Update page progress
-oku status <reading|oku|finished|dnf> [--book <id>]
-oku sync                                      Refresh the local cache
-oku tui                                       Launch the dashboard
+oku reading|oku|finished|dnf [--refresh]
+oku now [--refresh]
+oku sync
+
+oku search <query> [--mode book|author|genre] [--limit N]
+oku status <reading|oku|finished|dnf> [--book ID]
+oku update --page <N|+N|-N> [--book ID]
+
+oku active
+oku set-active --book ID
+oku open
+
+oku tui
 ```
 
-There are shortcuts for listing shelves:
+Global flags:
 
-```bash
-oku reading    # currently reading
-oku oku        # want to read
-oku finished   # done
-oku dnf        # did not finish
-```
+- `--json` return JSON output
+- `--view compact|default|verbose` control CLI/TUI output density
 
-Add `--json` to any CLI command for machine-readable output.
-Use `--view compact|default|verbose` for text density in list/active output.
+Exit codes:
 
-Exit codes: `0` success, `1` user/app error, `2` network/transient failure.
+- `0` success
+- `1` validation/app error
+- `2` network/transient API error
 
-## TUI Dashboard
+## TUI (LazyGit-Style Flow)
 
-Just run `oku` in a terminal (or `oku tui` explicitly).
+Run with `oku` (interactive terminal) or `oku tui`.
 
-The dashboard has **Reading** and **Oku** lists stacked vertically on the left, with a full-height **Output** panel on the right showing book details. Press `?` at any time to open the help modal with all keybindings.
+Layout:
 
-### Keybindings
+- Left: `Reading`, `Oku`, and search input
+- Right: selected book details or search results
 
-**Library view:**
+Key controls:
 
-| Key | Action |
-|-----|--------|
-| `h` / `l` (`←` / `→`) | Move focus between panes |
-| `/` | Jump to search input (insert mode) |
-| `Enter` | Toggle selected book between Reading and Oku |
-| `+` / `-` | Quick page update (+/- 10 pages) |
-| `u` | Update page progress |
-| `g` `w` `f` `d` | Move to Reading / Oku / Finished / DNF |
-| `x` | Remove book from library lists |
-| `z` | Cycle density (compact/default/verbose) |
-| `r` | Refresh from API |
-| `s` | Sync all statuses |
-| `?` | Show help modal |
-| `q` | Quit |
+### Global
 
-**Search panel:**
+- `h` / `l` or `←` / `→`: move between panes
+- `j` / `k`: move in lists
+- `?`: help
+- `q`: quit
 
-| Key | Action |
-|-----|--------|
-| `i` / `a` | Enter insert mode |
-| Type + `Enter` | Search (insert mode) |
-| `Esc` | Insert -> normal, then normal -> library |
-| `h` / `l` (`←` / `→`) | Move focus between panes (normal mode) |
-| `m` | Cycle mode: Book -> Author -> Genre |
-| `1` / `2` / `3` | Set mode: Book / Author / Genre |
-| `z` | Cycle density (compact/default/verbose) |
-| `Enter` on result | Add to Reading |
-| `g` `w` `f` `d` | Assign status to result |
-| `?` | Show help modal |
+### Library Panes
 
-## How Caching Works
+- `Enter`: toggle selected book between `Reading` and `Oku`
+- `+` / `-`: quick page update (`+10` / `-10`)
+- `u`: custom page update
+- `g` / `w` / `f` / `d`: set status (reading / want / finished / dnf)
+- `x`: remove from lists
+- `z`: cycle density (compact/default/verbose)
+- `r`: refresh
+- `s`: sync all
+- `/`: focus search input
 
-Oku tries to be a good API citizen. It caches aggressively and only hits Hardcover when it needs to:
+### Search Input
 
-- **Cache-first** for all status lists
-- **Auto-refresh** when the cache is empty or older than **6 hours**
-- **Manual refresh** with `--refresh` on any list command, or `oku sync` for everything
-- **Clean replacement** on sync -- no stale leftovers
-- **Orphan pruning** -- cached books not referenced by any list are cleaned up after 30 days
+- `i` or `a`: enter insert mode
+- `Esc`: insert -> normal (no forced pane jump)
+- `Enter`: run search
+- `m`: cycle mode (`book -> author -> genre`)
+- `1` / `2` / `3`: set mode directly
+- In normal mode, `h/l` navigates panes (does not type)
 
-Under the hood, the API client talks to `https://api.hardcover.app/v1/graphql` with a ~1 req/sec throttle, 30s timeout, and automatic retries on transient errors (`429`, `5xx`, deadline exceeded). User cancellations are respected and not retried.
+### Search Results
 
-## Configuration
+- `Enter`: add selected result to reading
+- `g` / `w` / `f` / `d`: add result with selected status
+- `Esc`: back to search input
 
-Config lives at `~/.config/oku/config.toml` (or `$XDG_CONFIG_HOME/oku/config.toml`).
+## Data Shown
+
+CLI/TUI details include:
+
+- title, authors, progress, pages
+- rating and rating counts
+- review/user popularity counts
+- release date
+- slug and IDs in verbose views
+
+Search supports intent-based discovery:
+
+- `book`: title-weighted
+- `author`: author-weighted
+- `genre`: genre/tag-weighted
+
+## Cache + API Behavior
+
+- Cache-first reads from SQLite
+- Auto-refresh if cache is empty or stale (6h)
+- `--refresh` forces API refresh for list commands
+- `oku sync` refreshes all statuses
+- API client uses timeout, retry, and throttling (~1 req/sec)
+
+## Config + Data Paths
+
+- Config: `~/.config/oku/config.toml` (or `$XDG_CONFIG_HOME/oku/config.toml`)
+- Data: `~/.local/share/oku/` (or `$XDG_DATA_HOME/oku/`)
+- DB file: `~/.local/share/oku/oku.db` (XDG equivalent)
+
+Example config:
 
 ```toml
 editor = "nvim"
@@ -143,40 +154,9 @@ use_fzf = false
 default_list = "reading"
 ```
 
-Data and cache are stored under `~/.local/share/oku/` (or `$XDG_DATA_HOME/oku/`).
-
-## Architecture
-
-For anyone poking around the code:
-
-```
-cmd/oku/          Entrypoint
-internal/
-  cli/            Cobra commands + TUI
-  app/            Business logic, orchestration
-  api/            Hardcover GraphQL client
-  store/          SQLite cache and state
-  auth/           Token resolution + keychain
-  config/         Config loading and XDG paths
-  model/          Domain types, statuses, page parsing
-  picker/         Interactive list picker (fzf-style)
-```
-
-The flow is straightforward: CLI/TUI -> `app` -> `store` + `api`. The app layer owns the logic, the store owns the cache, and the API client handles Hardcover.
-
 ## Development
 
 ```bash
 go test ./...
-go vet ./...
 go build ./cmd/oku
 ```
-
-Smoke test checklist:
-
-1. `oku auth set-token`
-2. `oku sync`
-3. `oku search "east of eden"`
-4. `oku tui`
-5. `oku update --page 50`
-6. Check your progress on [hardcover.app](https://hardcover.app) to confirm it synced

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ oku dnf        # did not finish
 ```
 
 Add `--json` to any CLI command for machine-readable output.
+Use `--view compact|default|verbose` for text density in list/active output.
 
 Exit codes: `0` success, `1` user/app error, `2` network/transient failure.
 
@@ -95,9 +96,11 @@ The dashboard has **Reading** and **Oku** lists stacked vertically on the left, 
 | `h` / `l` (`←` / `→`) | Move focus between panes |
 | `/` | Jump to search input (insert mode) |
 | `Enter` | Toggle selected book between Reading and Oku |
+| `+` / `-` | Quick page update (+/- 10 pages) |
 | `u` | Update page progress |
 | `g` `w` `f` `d` | Move to Reading / Oku / Finished / DNF |
 | `x` | Remove book from library lists |
+| `z` | Cycle density (compact/default/verbose) |
 | `r` | Refresh from API |
 | `s` | Sync all statuses |
 | `?` | Show help modal |
@@ -113,6 +116,7 @@ The dashboard has **Reading** and **Oku** lists stacked vertically on the left, 
 | `h` / `l` (`←` / `→`) | Move focus between panes (normal mode) |
 | `m` | Cycle mode: Book -> Author -> Genre |
 | `1` / `2` / `3` | Set mode: Book / Author / Genre |
+| `z` | Cycle density (compact/default/verbose) |
 | `Enter` on result | Add to Reading |
 | `g` `w` `f` `d` | Assign status to result |
 | `?` | Show help modal |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ oku config edit                               Open config in your editor
 oku config show                               Print current config
 oku list <reading|oku|finished|dnf> [--refresh]
 oku now [--refresh]                           What are you reading right now?
-oku search <query> [--limit N]                Search Hardcover
+oku search <query> [--limit N] [--mode M]     Search Hardcover (book/author/genre)
 oku set-active --book <id>                    Add a book to your active list
 oku open                                      Pick a currently-reading book and add it to active list
 oku update --page <N|+N|-N> [--book <id>]     Update page progress
@@ -111,6 +111,8 @@ The dashboard has **Reading** and **Oku** lists stacked vertically on the left, 
 | Type + `Enter` | Search (insert mode) |
 | `Esc` | Insert -> normal, then normal -> library |
 | `h` / `l` (`←` / `→`) | Move focus between panes (normal mode) |
+| `m` | Cycle mode: Book -> Author -> Genre |
+| `1` / `2` / `3` | Set mode: Book / Author / Genre |
 | `Enter` on result | Add to Reading |
 | `g` `w` `f` `d` | Assign status to result |
 | `?` | Show help modal |

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -127,26 +127,42 @@ func isSchemaFieldError(err error) bool {
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "cannot query field") ||
 		strings.Contains(msg, "unknown field") ||
+		strings.Contains(msg, "unknown argument") ||
 		strings.Contains(msg, "field ") && strings.Contains(msg, " not found")
 }
 
 // SearchBooks searches for books by query string and returns parsed results.
-func (c *Client) SearchBooks(ctx context.Context, query string, perPage int) ([]model.SearchResult, error) {
+func (c *Client) SearchBooks(ctx context.Context, query string, perPage int, mode model.SearchMode) ([]model.SearchResult, error) {
 	// Escape double quotes and backslashes in user input for safe embedding in the query string.
 	sanitized := strings.ReplaceAll(query, `\`, `\\`)
 	sanitized = strings.ReplaceAll(sanitized, `"`, `\"`)
 
+	config := searchConfigForMode(mode)
+
 	q := fmt.Sprintf(`query {
-  search(query: "%s", query_type: "Book", per_page: %d, page: 1) {
+  search(query: "%s", query_type: "Book", per_page: %d, page: 1%s%s) {
     results
   }
-}`, sanitized, perPage)
+}`, sanitized, perPage, config.fieldsArg, config.weightsArg)
 
 	req := graphql.NewRequest(q)
 
 	var resp SearchResponse
 	if err := c.do(ctx, req, &resp); err != nil {
-		return nil, fmt.Errorf("SearchBooks: %w", err)
+		// If a mode-specific search field is unsupported, transparently fall back.
+		if isSchemaFieldError(err) {
+			q = fmt.Sprintf(`query {
+  search(query: "%s", query_type: "Book", per_page: %d, page: 1) {
+    results
+  }
+}`, sanitized, perPage)
+			req = graphql.NewRequest(q)
+			if err := c.do(ctx, req, &resp); err != nil {
+				return nil, fmt.Errorf("SearchBooks: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("SearchBooks: %w", err)
+		}
 	}
 
 	var tsResults TypesenseResults
@@ -171,4 +187,29 @@ func (c *Client) SearchBooks(ctx context.Context, query string, perPage int) ([]
 	}
 
 	return results, nil
+}
+
+type searchQueryConfig struct {
+	fieldsArg  string
+	weightsArg string
+}
+
+func searchConfigForMode(mode model.SearchMode) searchQueryConfig {
+	switch mode {
+	case model.SearchModeAuthor:
+		return searchQueryConfig{
+			fieldsArg:  `, fields: "author_names,title"`,
+			weightsArg: `, weights: "8,2"`,
+		}
+	case model.SearchModeGenre:
+		return searchQueryConfig{
+			fieldsArg:  `, fields: "genres,tags,title,author_names"`,
+			weightsArg: `, weights: "8,5,2,1"`,
+		}
+	default:
+		return searchQueryConfig{
+			fieldsArg:  `, fields: "title,author_names"`,
+			weightsArg: `, weights: "7,3"`,
+		}
+	}
 }

--- a/internal/api/queries_test.go
+++ b/internal/api/queries_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/Kameleon21/oku/internal/model"
+)
+
+func TestSearchConfigForMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        model.SearchMode
+		wantFields  string
+		wantWeights string
+	}{
+		{
+			name:        "book default",
+			mode:        model.SearchModeBook,
+			wantFields:  `, fields: "title,author_names"`,
+			wantWeights: `, weights: "7,3"`,
+		},
+		{
+			name:        "author",
+			mode:        model.SearchModeAuthor,
+			wantFields:  `, fields: "author_names,title"`,
+			wantWeights: `, weights: "8,2"`,
+		},
+		{
+			name:        "genre",
+			mode:        model.SearchModeGenre,
+			wantFields:  `, fields: "genres,tags,title,author_names"`,
+			wantWeights: `, weights: "8,5,2,1"`,
+		},
+		{
+			name:        "unknown falls back to book",
+			mode:        model.SearchMode("x"),
+			wantFields:  `, fields: "title,author_names"`,
+			wantWeights: `, weights: "7,3"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := searchConfigForMode(tt.mode)
+			if got.fieldsArg != tt.wantFields || got.weightsArg != tt.wantWeights {
+				t.Fatalf("searchConfigForMode(%q) = %+v, want fields=%q weights=%q",
+					tt.mode, got, tt.wantFields, tt.wantWeights)
+			}
+		})
+	}
+}

--- a/internal/api/types_test.go
+++ b/internal/api/types_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFlexibleIntUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    FlexibleInt
+		wantErr bool
+	}{
+		{name: "number", in: `123`, want: 123},
+		{name: "quoted number", in: `"456"`, want: 456},
+		{name: "null", in: `null`, want: 0},
+		{name: "quoted empty", in: `""`, want: 0},
+		{name: "invalid", in: `"abc"`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got FlexibleInt
+			err := json.Unmarshal([]byte(tt.in), &got)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %s", tt.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %s: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Fatalf("value = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTypesenseResultsUnmarshalWithMixedNumericFormats(t *testing.T) {
+	raw := []byte(`{
+  "hits": [
+    {"document": {"id": "101", "title": "Dune", "author_names": ["Frank Herbert"], "pages": 412, "slug": "dune"}},
+    {"document": {"id": 202, "title": "Foundation", "author_names": ["Isaac Asimov"], "pages": "255", "slug": "foundation"}}
+  ]
+}`)
+
+	var results TypesenseResults
+	if err := json.Unmarshal(raw, &results); err != nil {
+		t.Fatalf("unmarshal typesense results: %v", err)
+	}
+	if len(results.Hits) != 2 {
+		t.Fatalf("hits len = %d, want 2", len(results.Hits))
+	}
+
+	first := results.Hits[0].Document
+	if int(first.ID) != 101 || int(first.Pages) != 412 {
+		t.Fatalf("first doc parse mismatch: id=%d pages=%d", first.ID, first.Pages)
+	}
+
+	second := results.Hits[1].Document
+	if int(second.ID) != 202 || int(second.Pages) != 255 {
+		t.Fatalf("second doc parse mismatch: id=%d pages=%d", second.ID, second.Pages)
+	}
+}

--- a/internal/app/list_convert_test.go
+++ b/internal/app/list_convert_test.go
@@ -1,0 +1,142 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Kameleon21/oku/internal/api"
+	"github.com/Kameleon21/oku/internal/model"
+)
+
+func TestParseAPITimeSupportsCommonLayouts(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		ok   bool
+	}{
+		{name: "rfc3339", in: "2025-02-03T04:05:06Z", ok: true},
+		{name: "rfc3339nano", in: "2025-02-03T04:05:06.123456789Z", ok: true},
+		{name: "date-only", in: "2025-02-03", ok: true},
+		{name: "invalid", in: "not-a-time", ok: false},
+		{name: "empty", in: "   ", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := parseAPITime(tt.in)
+			if ok != tt.ok {
+				t.Fatalf("parseAPITime(%q) ok=%v, want %v", tt.in, ok, tt.ok)
+			}
+		})
+	}
+}
+
+func TestConvertAPIUserBookMapsExtendedFields(t *testing.T) {
+	releaseDate := " 2024-01-05 "
+	updatedAt := "2025-02-03T04:05:06Z"
+	startedAt := "2025-01-01"
+	finishedAt := "2025-01-09T12:00:00Z"
+
+	contrib := api.APIContribution{}
+	contrib.Author.Name = "Neal Ford"
+
+	ab := api.APIUserBook{
+		ID:        77,
+		StatusID:  int(model.StatusCurrentlyReading),
+		UpdatedAt: &updatedAt,
+		Book: api.APIBook{
+			ID:             99,
+			Title:          "Software Architecture",
+			Pages:          450,
+			Slug:           "software-architecture",
+			Rating:         4.25,
+			RatingsCount:   1234,
+			ReviewsCount:   321,
+			UsersCount:     4567,
+			UsersReadCount: 3456,
+			ReleaseDate:    &releaseDate,
+			Contributions:  []api.APIContribution{contrib},
+			Image:          &api.APIImage{URL: "https://example.com/book.jpg"},
+		},
+		UserBookReads: []api.APIUserBookRead{
+			{
+				ID:            15,
+				ProgressPages: 88,
+				StartedAt:     &startedAt,
+				FinishedAt:    &finishedAt,
+			},
+		},
+	}
+
+	got := convertAPIUserBook(ab)
+	if got.ID != 77 || got.BookID != 99 {
+		t.Fatalf("ids = userBook:%d book:%d, want 77/99", got.ID, got.BookID)
+	}
+	if got.StatusID != model.StatusCurrentlyReading {
+		t.Fatalf("status = %v, want currently reading", got.StatusID)
+	}
+	if got.Book.Title != "Software Architecture" || got.Book.Slug != "software-architecture" {
+		t.Fatalf("book title/slug not mapped: %+v", got.Book)
+	}
+	if got.Book.ImageURL != "https://example.com/book.jpg" {
+		t.Fatalf("image url = %q", got.Book.ImageURL)
+	}
+	if got.Book.ReleaseDate != "2024-01-05" {
+		t.Fatalf("release date = %q, want trimmed value", got.Book.ReleaseDate)
+	}
+	if len(got.Book.Authors) != 1 || got.Book.Authors[0] != "Neal Ford" {
+		t.Fatalf("authors = %#v, want [Neal Ford]", got.Book.Authors)
+	}
+	if got.Book.Rating != 4.25 || got.Book.RatingsCount != 1234 || got.Book.ReviewsCount != 321 {
+		t.Fatalf("book metrics not mapped: %+v", got.Book)
+	}
+	if got.Book.UsersCount != 4567 || got.Book.UsersReadCount != 3456 {
+		t.Fatalf("reader counts not mapped: users=%d read=%d", got.Book.UsersCount, got.Book.UsersReadCount)
+	}
+
+	wantUpdated, _ := time.Parse(time.RFC3339, updatedAt)
+	if !got.UpdatedAt.Equal(wantUpdated.UTC()) {
+		t.Fatalf("updated_at = %s, want %s", got.UpdatedAt, wantUpdated.UTC())
+	}
+	if len(got.UserBookReads) != 1 {
+		t.Fatalf("read entries = %d, want 1", len(got.UserBookReads))
+	}
+	read := got.UserBookReads[0]
+	if read.UserBookID != 77 || read.ProgressPages != 88 {
+		t.Fatalf("read mapping mismatch: %+v", read)
+	}
+	if read.StartedAt == nil || read.FinishedAt == nil {
+		t.Fatalf("expected parsed started/finished times, got %+v", read)
+	}
+}
+
+func TestConvertAPIUserBookFallsBackWhenTimesInvalid(t *testing.T) {
+	invalidUpdatedAt := "not-a-time"
+	invalidStartedAt := "bad"
+
+	before := time.Now().UTC()
+	ab := api.APIUserBook{
+		ID:        1,
+		StatusID:  int(model.StatusWantToRead),
+		UpdatedAt: &invalidUpdatedAt,
+		Book: api.APIBook{
+			ID:    2,
+			Title: "Book",
+		},
+		UserBookReads: []api.APIUserBookRead{
+			{ID: 3, ProgressPages: 10, StartedAt: &invalidStartedAt},
+		},
+	}
+	got := convertAPIUserBook(ab)
+	after := time.Now().UTC()
+
+	if got.UpdatedAt.Before(before.Add(-time.Second)) || got.UpdatedAt.After(after.Add(time.Second)) {
+		t.Fatalf("updated_at fallback out of range: %s (before=%s after=%s)", got.UpdatedAt, before, after)
+	}
+	if len(got.UserBookReads) != 1 {
+		t.Fatalf("read entries = %d, want 1", len(got.UserBookReads))
+	}
+	if got.UserBookReads[0].StartedAt != nil {
+		t.Fatalf("started_at should stay nil on parse failure, got %v", got.UserBookReads[0].StartedAt)
+	}
+}

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -6,11 +6,14 @@ import (
 	"github.com/Kameleon21/oku/internal/model"
 )
 
-// SearchBooks queries the Hardcover API for books matching the query.
+// SearchBooks queries the Hardcover API for books matching the query and mode.
 // Search always hits the API (not cache) since it uses Typesense.
-func (a *App) SearchBooks(ctx context.Context, query string, limit int) ([]model.SearchResult, error) {
+func (a *App) SearchBooks(ctx context.Context, query string, limit int, mode model.SearchMode) ([]model.SearchResult, error) {
 	if limit <= 0 {
 		limit = 10
 	}
-	return a.API.SearchBooks(ctx, query, limit)
+	if mode == "" {
+		mode = model.SearchModeBook
+	}
+	return a.API.SearchBooks(ctx, query, limit, mode)
 }

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -19,6 +19,35 @@ var (
 	dimStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 )
 
+type outputDensity int
+
+const (
+	densityCompact outputDensity = iota
+	densityDefault
+	densityVerbose
+)
+
+func parseOutputDensity(raw string) (outputDensity, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "default":
+		return densityDefault, nil
+	case "compact":
+		return densityCompact, nil
+	case "verbose":
+		return densityVerbose, nil
+	default:
+		return densityDefault, fmt.Errorf("invalid --view value %q (valid: compact, default, verbose)", raw)
+	}
+}
+
+func currentOutputDensity() outputDensity {
+	d, err := parseOutputDensity(outputView)
+	if err != nil {
+		return densityDefault
+	}
+	return d
+}
+
 func printBooks(books []model.UserBook) {
 	if jsonOutput {
 		printJSON(books)
@@ -28,19 +57,34 @@ func printBooks(books []model.UserBook) {
 		fmt.Println(dimStyle.Render("No books found."))
 		return
 	}
+	density := currentOutputDensity()
 	for i, ub := range books {
 		num := dimStyle.Render(fmt.Sprintf("%d.", i+1))
 		title := titleStyle.Render(ub.Book.Title)
 		author := authorStyle.Render(ub.Book.AuthorString())
 		progress := pageStyle.Render(ub.Progress())
+		meta := bookMetaLine(ub.Book)
+		detail := bookDetailLine(ub.Book)
+
+		if density == densityCompact {
+			if meta != "" {
+				fmt.Printf("%s %s  %s  %s\n", num, title, progress, dimStyle.Render(meta))
+			} else {
+				fmt.Printf("%s %s  %s\n", num, title, progress)
+			}
+			continue
+		}
 
 		fmt.Printf("%s %s\n", num, title)
-		if author != "" {
+		if author != "" && density != densityCompact {
 			fmt.Printf("   %s\n", author)
 		}
 		fmt.Printf("   %s\n", progress)
-		if meta := bookMetaLine(ub.Book); meta != "" {
+		if meta != "" {
 			fmt.Printf("   %s\n", dimStyle.Render(meta))
+		}
+		if density == densityVerbose && detail != "" {
+			fmt.Printf("   %s\n", dimStyle.Render(detail))
 		}
 	}
 }
@@ -82,18 +126,35 @@ func printActiveBooks(books []model.UserBook) {
 		return
 	}
 
+	density := currentOutputDensity()
 	fmt.Println(statusStyle.Render("Active Books"))
 	for i, ub := range books {
 		num := dimStyle.Render(fmt.Sprintf("%d.", i+1))
+		progress := pageStyle.Render(ub.Progress())
+		meta := bookMetaLine(ub.Book)
+		detail := bookDetailLine(ub.Book)
+
+		if density == densityCompact {
+			if meta != "" {
+				fmt.Printf("%s %s  %s  %s\n", num, titleStyle.Render(ub.Book.Title), progress, dimStyle.Render(meta))
+			} else {
+				fmt.Printf("%s %s  %s\n", num, titleStyle.Render(ub.Book.Title), progress)
+			}
+			continue
+		}
+
 		fmt.Printf("%s %s\n", num, titleStyle.Render(ub.Book.Title))
 		if a := ub.Book.AuthorString(); a != "" {
 			fmt.Printf("      %s\n", authorStyle.Render(a))
 		}
 		fmt.Printf("      %s  %s\n",
-			pageStyle.Render(ub.Progress()),
+			progress,
 			statusStyle.Render(ub.StatusID.Label()))
-		if meta := bookMetaLine(ub.Book); meta != "" {
+		if meta != "" {
 			fmt.Printf("      %s\n", dimStyle.Render(meta))
+		}
+		if density == densityVerbose && detail != "" {
+			fmt.Printf("      %s\n", dimStyle.Render(detail))
 		}
 	}
 }
@@ -125,6 +186,20 @@ func bookMetaLine(b model.Book) string {
 		parts = append(parts, series)
 	}
 
+	return strings.Join(parts, " · ")
+}
+
+func bookDetailLine(b model.Book) string {
+	parts := make([]string, 0, 3)
+	if b.Slug != "" {
+		parts = append(parts, "slug:"+b.Slug)
+	}
+	if b.Pages > 0 {
+		parts = append(parts, fmt.Sprintf("%d pages", b.Pages))
+	}
+	if b.ID > 0 {
+		parts = append(parts, fmt.Sprintf("id:%d", b.ID))
+	}
 	return strings.Join(parts, " · ")
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -14,12 +14,17 @@ import (
 )
 
 var jsonOutput bool
+var outputView string
 
 func newRootCmd(version string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "oku",
 		Short:   "A fast CLI for Hardcover",
 		Version: version,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			_, err := parseOutputDensity(outputView)
+			return err
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !isInteractiveTerminal(os.Stdin) || !isInteractiveTerminal(os.Stdout) {
 				return cmd.Help()
@@ -31,6 +36,7 @@ func newRootCmd(version string) *cobra.Command {
 	cmd.SilenceUsage = true
 
 	cmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+	cmd.PersistentFlags().StringVar(&outputView, "view", "default", "Output density: compact, default, verbose")
 
 	// Auth commands don't need the full app setup.
 	cmd.AddCommand(newAuthCmd())

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -3,25 +3,31 @@ package cli
 import (
 	"strings"
 
+	"github.com/Kameleon21/oku/internal/model"
 	"github.com/spf13/cobra"
 )
 
 func newSearchCmd() *cobra.Command {
 	var limit int
+	var modeRaw string
 
 	cmd := &cobra.Command{
 		Use:   "search <query>",
-		Short: "Search for books on Hardcover",
+		Short: "Search Hardcover (book/author/genre intent)",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			query := strings.Join(args, " ")
+			mode, err := model.ParseSearchMode(modeRaw)
+			if err != nil {
+				return err
+			}
 			a, err := initApp()
 			if err != nil {
 				return err
 			}
 			defer a.Store.Close()
 
-			results, err := a.SearchBooks(ctx(), query, limit)
+			results, err := a.SearchBooks(ctx(), query, limit, mode)
 			if err != nil {
 				return err
 			}
@@ -30,5 +36,6 @@ func newSearchCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&limit, "limit", 10, "Max results to return")
+	cmd.Flags().StringVar(&modeRaw, "mode", "book", "Search mode: book, author, genre")
 	return cmd
 }

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -1243,6 +1243,9 @@ func (m dashboardModel) changeSelectedSearchStatus(status model.Status) (tea.Mod
 
 func loadLibraryCmd(a *app.App, refresh bool) tea.Cmd {
 	return func() tea.Msg {
+		if a == nil {
+			return libraryLoadedMsg{err: fmt.Errorf("dashboard app is not initialized")}
+		}
 		reading, err := a.ListBooks(ctx(), model.StatusCurrentlyReading, refresh)
 		if err != nil {
 			return libraryLoadedMsg{err: err}

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -44,7 +44,8 @@ const (
 )
 
 type userBookItem struct {
-	book model.UserBook
+	book    model.UserBook
+	density outputDensity
 }
 
 func (i userBookItem) Title() string {
@@ -64,7 +65,18 @@ func (i userBookItem) Description() string {
 		}
 		progress += " " + miniProgressBar(page, i.book.Book.Pages, 8)
 	}
-	return fmt.Sprintf("%s · %s", author, progress)
+
+	switch i.density {
+	case densityCompact:
+		return progress
+	case densityVerbose:
+		if meta := bookMetaLine(i.book.Book); meta != "" {
+			return fmt.Sprintf("%s · %s · %s", author, progress, meta)
+		}
+		return fmt.Sprintf("%s · %s", author, progress)
+	default:
+		return fmt.Sprintf("%s · %s", author, progress)
+	}
 }
 
 func (i userBookItem) FilterValue() string {
@@ -150,6 +162,7 @@ type dashboardModel struct {
 	searchMode         searchInputMode
 	searchQueryMode    model.SearchMode
 	recentSearches     []string
+	density            outputDensity
 
 	showHelp bool
 }
@@ -229,6 +242,7 @@ func newDashboardModel(a *app.App) dashboardModel {
 		focus:           focusReading,
 		searchMode:      searchModeNormal,
 		searchQueryMode: model.SearchModeBook,
+		density:         currentOutputDensity(),
 		readingList:     newList("Reading"),
 		okuList:         newList("Oku"),
 		searchList:      newList("Search Results"),
@@ -370,6 +384,9 @@ func (m dashboardModel) updateLibraryMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case "3":
 					m.setSearchQueryMode(model.SearchModeGenre)
 					return m, nil
+				case "z":
+					m.cycleDensity()
+					return m, nil
 				case "enter":
 					return m, m.submitSearch()
 				case "esc":
@@ -428,6 +445,9 @@ func (m dashboardModel) updateLibraryMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.changeSelectedSearchStatus(model.StatusRead)
 			case "d":
 				return m.changeSelectedSearchStatus(model.StatusDidNotFinish)
+			case "z":
+				m.cycleDensity()
+				return m, nil
 			case "h", "H", "left":
 				m.focusPrevPane()
 				return m, nil
@@ -467,11 +487,24 @@ func (m dashboardModel) updateLibraryMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "s":
 			m.loading = true
 			return m, syncAllAndReloadCmd(m.app)
+		case "z":
+			m.cycleDensity()
+			return m, nil
 		case "enter":
 			if m.focus == focusOku {
 				return m.changeSelectedLibraryStatus(model.StatusCurrentlyReading)
 			}
 			return m.changeSelectedLibraryStatus(model.StatusWantToRead)
+		case "+", "=":
+			if b := m.selectedLibraryBook(); b != nil {
+				m.loading = true
+				return m, quickProgressCmd(m.app, b.Book.ID, +10)
+			}
+		case "-":
+			if b := m.selectedLibraryBook(); b != nil {
+				m.loading = true
+				return m, quickProgressCmd(m.app, b.Book.ID, -10)
+			}
 		case "u":
 			if b := m.selectedLibraryBook(); b != nil {
 				m.mode = modeUpdatePage
@@ -530,6 +563,30 @@ func (m *dashboardModel) submitSearch() tea.Cmd {
 	)
 	m.searchList.Title = fmt.Sprintf("%s Results (loading...)", m.searchQueryMode.Label())
 	return searchCmd(m.app, query, m.searchQueryMode)
+}
+
+func (m *dashboardModel) cycleDensity() {
+	switch m.density {
+	case densityCompact:
+		m.density = densityDefault
+	case densityDefault:
+		m.density = densityVerbose
+	default:
+		m.density = densityCompact
+	}
+	m.refreshListItems()
+	m.infoMsg = "Density: " + densityLabel(m.density)
+}
+
+func densityLabel(d outputDensity) string {
+	switch d {
+	case densityCompact:
+		return "compact"
+	case densityVerbose:
+		return "verbose"
+	default:
+		return "default"
+	}
 }
 
 func (m *dashboardModel) setSearchQueryMode(mode model.SearchMode) {
@@ -886,55 +943,62 @@ func (m dashboardModel) detailsView() string {
 	}
 	writeField("Progress", progressText)
 
-	writeField("Book ID", fmt.Sprintf("%d", b.Book.ID))
-
-	if b.Book.Pages > 0 {
-		writeField("Pages", fmt.Sprintf("%d", b.Book.Pages))
-	}
-	if b.Book.Rating > 0 {
-		rating := fmt.Sprintf("%.2f", b.Book.Rating)
-		if b.Book.RatingsCount > 0 {
-			rating += fmt.Sprintf(" (%s ratings)", formatCount(b.Book.RatingsCount))
+	if m.density != densityCompact {
+		writeField("Book ID", fmt.Sprintf("%d", b.Book.ID))
+		if b.Book.Pages > 0 {
+			writeField("Pages", fmt.Sprintf("%d", b.Book.Pages))
 		}
-		writeField("Rating", rating)
-	}
-	if b.Book.ReviewsCount > 0 {
-		writeField("Reviews", formatCount(b.Book.ReviewsCount))
-	}
-	if b.Book.UsersReadCount > 0 || b.Book.UsersCount > 0 {
-		readers := ""
-		if b.Book.UsersReadCount > 0 {
-			readers = formatCount(b.Book.UsersReadCount) + " read"
-		}
-		if b.Book.UsersCount > 0 {
-			if readers != "" {
-				readers += " · "
+		if b.Book.Rating > 0 {
+			rating := fmt.Sprintf("%.2f", b.Book.Rating)
+			if b.Book.RatingsCount > 0 {
+				rating += fmt.Sprintf(" (%s ratings)", formatCount(b.Book.RatingsCount))
 			}
-			readers += formatCount(b.Book.UsersCount) + " shelved"
+			writeField("Rating", rating)
 		}
-		writeField("Readers", readers)
-	}
-	if b.Book.ReleaseDate != "" {
-		writeField("Released", b.Book.ReleaseDate)
-	}
-	if b.Book.FeaturedSeries != "" {
-		series := b.Book.FeaturedSeries
-		if b.Book.FeaturedSeriesPosition > 0 {
-			series += fmt.Sprintf(" #%d", b.Book.FeaturedSeriesPosition)
+		if b.Book.ReviewsCount > 0 {
+			writeField("Reviews", formatCount(b.Book.ReviewsCount))
 		}
-		writeField("Series", series)
-	}
-	if b.Book.Slug != "" {
-		writeField("Slug", b.Book.Slug)
-	}
-	if len(b.UserBookReads) > 0 {
-		if b.UserBookReads[0].StartedAt != nil {
-			writeField("Started", b.UserBookReads[0].StartedAt.Format("2006-01-02"))
+		if b.Book.UsersReadCount > 0 || b.Book.UsersCount > 0 {
+			readers := ""
+			if b.Book.UsersReadCount > 0 {
+				readers = formatCount(b.Book.UsersReadCount) + " read"
+			}
+			if b.Book.UsersCount > 0 {
+				if readers != "" {
+					readers += " · "
+				}
+				readers += formatCount(b.Book.UsersCount) + " shelved"
+			}
+			writeField("Readers", readers)
 		}
-		if b.UserBookReads[0].FinishedAt != nil {
-			writeField("Finished", b.UserBookReads[0].FinishedAt.Format("2006-01-02"))
+		if b.Book.ReleaseDate != "" {
+			writeField("Released", b.Book.ReleaseDate)
+		}
+		if b.Book.FeaturedSeries != "" {
+			series := b.Book.FeaturedSeries
+			if b.Book.FeaturedSeriesPosition > 0 {
+				series += fmt.Sprintf(" #%d", b.Book.FeaturedSeriesPosition)
+			}
+			writeField("Series", series)
 		}
 	}
+
+	if m.density == densityVerbose {
+		if b.Book.Slug != "" {
+			writeField("Slug", b.Book.Slug)
+		}
+		if len(b.UserBookReads) > 0 {
+			if b.UserBookReads[0].StartedAt != nil {
+				writeField("Started", b.UserBookReads[0].StartedAt.Format("2006-01-02"))
+			}
+			if b.UserBookReads[0].FinishedAt != nil {
+				writeField("Finished", b.UserBookReads[0].FinishedAt.Format("2006-01-02"))
+			}
+		}
+	}
+
+	sb.WriteString("\n")
+	sb.WriteString(dimStyleTUI.Render("  Quick: Enter toggle  +/- page  u custom  g/w/f/d status  x remove  z density"))
 
 	return sb.String()
 }
@@ -997,12 +1061,14 @@ func (m dashboardModel) renderHelpModal() string {
 		}),
 		section("Library Actions", [][2]string{
 			{"Enter", "Toggle reading / oku"},
+			{"+ / -", "Quick page update (+/-10)"},
 			{"u", "Update page progress"},
 			{"g", "Set status: reading"},
 			{"w", "Set status: want to read"},
 			{"f", "Set status: finished"},
 			{"d", "Set status: did not finish"},
 			{"x", "Remove from library"},
+			{"z", "Cycle density: compact/default/verbose"},
 		}),
 		section("Data", [][2]string{
 			{"r", "Refresh from cache"},
@@ -1064,6 +1130,7 @@ func (m dashboardModel) libraryHelp() string {
 			{"w", "want"},
 			{"f", "finished"},
 			{"d", "dnf"},
+			{"z", "density"},
 			{"h/l", "pane"},
 			{"Esc", "back"},
 			{"?", "help"},
@@ -1073,12 +1140,14 @@ func (m dashboardModel) libraryHelp() string {
 			{"h/l", "pane"},
 			{"/", "search"},
 			{"↵", "toggle read/oku"},
+			{"+/-", "page"},
 			{"u", "update"},
 			{"g", "reading"},
 			{"w", "want"},
 			{"f", "finished"},
 			{"d", "dnf"},
 			{"x", "remove"},
+			{"z", "density"},
 			{"r", "refresh"},
 			{"s", "sync"},
 			{"?", "help"},
@@ -1109,7 +1178,8 @@ func (m *dashboardModel) refreshListItems() {
 		items := make([]list.Item, 0, len(books))
 		for _, b := range books {
 			items = append(items, userBookItem{
-				book: b,
+				book:    b,
+				density: m.density,
 			})
 		}
 		return items
@@ -1212,6 +1282,30 @@ func updateProgressCmd(a *app.App, bookID int, rawPage string) tea.Cmd {
 		}
 		return opDoneMsg{
 			info:      fmt.Sprintf("Progress updated to page %d", newPage),
+			reload:    true,
+			markDirty: true,
+		}
+	}
+}
+
+func quickProgressCmd(a *app.App, bookID int, delta int) tea.Cmd {
+	return func() tea.Msg {
+		if delta == 0 {
+			return opDoneMsg{}
+		}
+		newPage, err := a.UpdateProgress(ctx(), bookID, model.PageUpdate{
+			Delta:    delta,
+			Relative: true,
+		})
+		if err != nil {
+			return opDoneMsg{err: err}
+		}
+		sign := ""
+		if delta > 0 {
+			sign = "+"
+		}
+		return opDoneMsg{
+			info:      fmt.Sprintf("Progress %s%d → page %d", sign, delta, newPage),
 			reload:    true,
 			markDirty: true,
 		}

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -103,6 +103,7 @@ type libraryLoadedMsg struct {
 type searchLoadedMsg struct {
 	results []model.SearchResult
 	query   string
+	mode    model.SearchMode
 	err     error
 }
 
@@ -147,6 +148,8 @@ type dashboardModel struct {
 	searchLoading      bool
 	searchLoadingQuery string
 	searchMode         searchInputMode
+	searchQueryMode    model.SearchMode
+	recentSearches     []string
 
 	showHelp bool
 }
@@ -206,6 +209,8 @@ func newDashboardModel(a *app.App) dashboardModel {
 	searchIn.Prompt = "/ "
 	searchIn.PromptStyle = lipgloss.NewStyle().Foreground(colorGold).Bold(true)
 	searchIn.TextStyle = lipgloss.NewStyle().Foreground(colorLightGray)
+	searchIn.ShowSuggestions = true
+	searchIn.SetSuggestions(defaultSearchSuggestions(model.SearchModeBook))
 
 	pageIn := textinput.New()
 	pageIn.Placeholder = "370 or +10 or -5"
@@ -219,16 +224,17 @@ func newDashboardModel(a *app.App) dashboardModel {
 	s.Style = lipgloss.NewStyle().Foreground(colorGold)
 
 	return dashboardModel{
-		app:         a,
-		mode:        modeLibrary,
-		focus:       focusReading,
-		searchMode:  searchModeNormal,
-		readingList: newList("Reading"),
-		okuList:     newList("Oku"),
-		searchList:  newList("Search Results"),
-		searchInput: searchIn,
-		pageInput:   pageIn,
-		spin:        s,
+		app:             a,
+		mode:            modeLibrary,
+		focus:           focusReading,
+		searchMode:      searchModeNormal,
+		searchQueryMode: model.SearchModeBook,
+		readingList:     newList("Reading"),
+		okuList:         newList("Oku"),
+		searchList:      newList("Search Results"),
+		searchInput:     searchIn,
+		pageInput:       pageIn,
+		spin:            s,
 	}
 }
 
@@ -267,6 +273,7 @@ func (m dashboardModel) updateLibraryMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.readingBooks = msg.reading
 		m.okuBooks = msg.oku
 		m.refreshListItems()
+		m.updateSearchSuggestions()
 		m.errMsg = ""
 		return m, nil
 	case searchLoadedMsg:
@@ -278,22 +285,25 @@ func (m dashboardModel) updateLibraryMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.infoMsg = ""
 			return m, nil
 		}
+		m.searchQueryMode = msg.mode
 		m.lastQuery = msg.query
 		items := make([]list.Item, 0, len(msg.results))
 		for _, r := range msg.results {
 			items = append(items, searchResultItem{result: r})
 		}
 		m.searchList.SetItems(items)
-		m.searchList.Title = fmt.Sprintf("Search Results (%d)", len(items))
+		m.searchList.Title = fmt.Sprintf("%s Results (%d)", m.searchQueryMode.Label(), len(items))
 		if len(items) > 0 {
 			m.focus = focusSearchResults
 		}
 		m.errMsg = ""
 		if len(items) == 0 {
-			m.infoMsg = fmt.Sprintf("No results for %q", msg.query)
+			m.infoMsg = fmt.Sprintf("%s mode: no results for %q", strings.ToLower(m.searchQueryMode.Label()), msg.query)
 		} else {
-			m.infoMsg = fmt.Sprintf("Loaded %d results", len(items))
+			m.infoMsg = fmt.Sprintf("%s mode: loaded %d results", strings.ToLower(m.searchQueryMode.Label()), len(items))
 		}
+		m.addRecentSearchQuery(msg.query)
+		m.updateSearchSuggestions()
 		return m, nil
 	case backgroundCheckMsg:
 		if m.dirty && !m.loading && time.Since(m.lastMutationAt) >= backgroundSyncWindow {
@@ -347,6 +357,18 @@ func (m dashboardModel) updateLibraryMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case "a":
 					m.enterSearchInsertMode()
 					m.searchInput.CursorEnd()
+					return m, nil
+				case "m":
+					m.setSearchQueryMode(m.searchQueryMode.Next())
+					return m, nil
+				case "1":
+					m.setSearchQueryMode(model.SearchModeBook)
+					return m, nil
+				case "2":
+					m.setSearchQueryMode(model.SearchModeAuthor)
+					return m, nil
+				case "3":
+					m.setSearchQueryMode(model.SearchModeGenre)
 					return m, nil
 				case "enter":
 					return m, m.submitSearch()
@@ -436,6 +458,7 @@ func (m dashboardModel) updateLibraryMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.focus = focusSearchInput
 			m.enterSearchInsertMode()
 			m.searchInput.SetValue("")
+			m.updateSearchSuggestions()
 			m.errMsg = ""
 			return m, nil
 		case "r":
@@ -500,9 +523,122 @@ func (m *dashboardModel) submitSearch() tea.Cmd {
 	m.searchLoading = true
 	m.searchLoadingQuery = query
 	m.errMsg = ""
-	m.infoMsg = fmt.Sprintf("Searching for: %q...", query)
-	m.searchList.Title = "Search Results (loading...)"
-	return searchCmd(m.app, query)
+	m.infoMsg = fmt.Sprintf("%s mode (%s): searching for %q...",
+		strings.ToLower(m.searchQueryMode.Label()),
+		m.searchQueryMode.Description(),
+		query,
+	)
+	m.searchList.Title = fmt.Sprintf("%s Results (loading...)", m.searchQueryMode.Label())
+	return searchCmd(m.app, query, m.searchQueryMode)
+}
+
+func (m *dashboardModel) setSearchQueryMode(mode model.SearchMode) {
+	if mode == "" {
+		mode = model.SearchModeBook
+	}
+	if m.searchQueryMode == mode {
+		return
+	}
+	m.searchQueryMode = mode
+	m.searchList.Title = fmt.Sprintf("%s Results", mode.Label())
+	m.infoMsg = fmt.Sprintf("Search mode: %s (%s)", strings.ToLower(mode.Label()), mode.Description())
+	m.searchInput.Placeholder = searchPlaceholderForMode(mode)
+	m.updateSearchSuggestions()
+}
+
+func (m *dashboardModel) addRecentSearchQuery(query string) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return
+	}
+	next := []string{query}
+	for _, q := range m.recentSearches {
+		if strings.EqualFold(q, query) {
+			continue
+		}
+		next = append(next, q)
+		if len(next) >= 8 {
+			break
+		}
+	}
+	m.recentSearches = next
+}
+
+func (m *dashboardModel) updateSearchSuggestions() {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, 12)
+
+	push := func(s string) {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return
+		}
+		key := strings.ToLower(s)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		out = append(out, s)
+	}
+
+	for _, s := range defaultSearchSuggestions(m.searchQueryMode) {
+		push(s)
+	}
+	for _, q := range m.recentSearches {
+		push(q)
+	}
+	if m.searchQueryMode == model.SearchModeAuthor {
+		for _, b := range append(append([]model.UserBook(nil), m.readingBooks...), m.okuBooks...) {
+			for _, a := range b.Book.Authors {
+				push(a)
+			}
+		}
+	}
+
+	if len(out) > 12 {
+		out = out[:12]
+	}
+	m.searchInput.SetSuggestions(out)
+}
+
+func defaultSearchSuggestions(mode model.SearchMode) []string {
+	switch mode {
+	case model.SearchModeAuthor:
+		return []string{
+			"Ursula K. Le Guin",
+			"Octavia Butler",
+			"Neal Ford",
+			"Fyodor Dostoevsky",
+			"James Clear",
+		}
+	case model.SearchModeGenre:
+		return []string{
+			"science fiction",
+			"classics",
+			"philosophy",
+			"software architecture",
+			"psychology",
+		}
+	default:
+		return []string{
+			"east of eden",
+			"dune",
+			"atomic habits",
+			"clean code",
+			"the brothers karamazov",
+		}
+	}
+}
+
+func searchPlaceholderForMode(mode model.SearchMode) string {
+	switch mode {
+	case model.SearchModeAuthor:
+		return "Search by author name..."
+	case model.SearchModeGenre:
+		return "Search by genre or tag..."
+	default:
+		return "Search books..."
+	}
 }
 
 func (m *dashboardModel) enterSearchNormalMode() {
@@ -808,7 +944,8 @@ func (m dashboardModel) searchInputWithModeBadge() string {
 	if m.searchMode == searchModeInsert {
 		mode = keyStyle.Render("[INSERT]")
 	}
-	return mode + " " + m.searchInput.View()
+	queryMode := keyStyle.Render("[" + m.searchQueryMode.Label() + "]")
+	return mode + " " + queryMode + " " + m.searchInput.View()
 }
 
 func (m dashboardModel) searchPanelView() string {
@@ -820,12 +957,17 @@ func (m dashboardModel) searchPanelView() string {
 		if strings.TrimSpace(query) == "" {
 			query = "..."
 		}
-		return "\n  " + m.spin.View() + " Searching for " + fmt.Sprintf("%q", query)
+		return "\n  " + m.spin.View() + " " + strings.ToLower(m.searchQueryMode.Label()) +
+			" search (" + m.searchQueryMode.Description() + ") for " + fmt.Sprintf("%q", query)
 	}
 
 	if len(m.searchList.Items()) == 0 {
 		if strings.TrimSpace(m.lastQuery) == "" {
-			return dimStyleTUI.Render("  Type a query and press Enter to search")
+			return dimStyleTUI.Render(
+				fmt.Sprintf("  %s mode (%s). Type a query and press Enter.",
+					strings.ToLower(m.searchQueryMode.Label()), m.searchQueryMode.Description(),
+				),
+			)
 		}
 		return dimStyleTUI.Render(fmt.Sprintf("  No results for %q", m.lastQuery))
 	}
@@ -871,6 +1013,8 @@ func (m dashboardModel) renderHelpModal() string {
 			{"i / a", "Enter insert mode"},
 			{"Esc", "Insert -> normal / back"},
 			{"h/l or ←/→", "Pane nav in normal mode"},
+			{"m", "Cycle mode: book/author/genre"},
+			{"1/2/3", "Set mode: book/author/genre"},
 			{"g/w/f/d", "Add result with status"},
 			{"Esc (results)", "Back to search input"},
 		}),
@@ -907,6 +1051,8 @@ func (m dashboardModel) libraryHelp() string {
 		return renderHelpBar([][2]string{
 			{"↵", "search"},
 			{"i/a", "insert"},
+			{"m", "mode"},
+			{"1/2/3", "book/author/genre"},
 			{"h/l", "pane"},
 			{"Esc", "back"},
 			{"?", "help"},
@@ -1042,12 +1188,13 @@ func loadLibraryCmd(a *app.App, refresh bool) tea.Cmd {
 	}
 }
 
-func searchCmd(a *app.App, query string) tea.Cmd {
+func searchCmd(a *app.App, query string, mode model.SearchMode) tea.Cmd {
 	return func() tea.Msg {
-		results, err := a.SearchBooks(ctx(), query, 10)
+		results, err := a.SearchBooks(ctx(), query, 10, mode)
 		return searchLoadedMsg{
 			results: results,
 			query:   query,
+			mode:    mode,
 			err:     err,
 		}
 	}

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -32,6 +32,22 @@ func TestSearchInputNormalModeUsesVimPaneNavigation(t *testing.T) {
 	}
 }
 
+func TestLoadLibraryCmdWithNilAppReturnsError(t *testing.T) {
+	cmd := loadLibraryCmd(nil, false)
+	if cmd == nil {
+		t.Fatal("loadLibraryCmd() returned nil cmd")
+	}
+
+	msg := cmd()
+	loaded, ok := msg.(libraryLoadedMsg)
+	if !ok {
+		t.Fatalf("loadLibraryCmd() msg type = %T, want libraryLoadedMsg", msg)
+	}
+	if loaded.err == nil {
+		t.Fatal("expected libraryLoadedMsg error for nil app")
+	}
+}
+
 func TestSearchInputInsertModeTypingAndEsc(t *testing.T) {
 	m := newDashboardModel(nil)
 	m.focus = focusSearchInput

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Kameleon21/oku/internal/model"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func runeKey(r rune) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+}
+
+func TestSearchInputNormalModeUsesVimPaneNavigation(t *testing.T) {
+	m := newDashboardModel(nil)
+	m.focus = focusSearchInput
+	m.searchMode = searchModeNormal
+	m.searchInput.SetValue("dune")
+
+	updated, _ := m.updateLibraryMode(runeKey('h'))
+	got := updated.(dashboardModel)
+
+	if got.focus != focusOku {
+		t.Fatalf("focus after h = %v, want %v", got.focus, focusOku)
+	}
+	if got.searchInput.Value() != "dune" {
+		t.Fatalf("search input changed in normal mode, got %q", got.searchInput.Value())
+	}
+	if got.searchMode != searchModeNormal {
+		t.Fatalf("search mode = %v, want normal", got.searchMode)
+	}
+}
+
+func TestSearchInputInsertModeTypingAndEsc(t *testing.T) {
+	m := newDashboardModel(nil)
+	m.focus = focusSearchInput
+	m.enterSearchInsertMode()
+
+	updated, _ := m.updateLibraryMode(runeKey('h'))
+	got := updated.(dashboardModel)
+
+	if got.focus != focusSearchInput {
+		t.Fatalf("focus after typing in insert mode = %v, want %v", got.focus, focusSearchInput)
+	}
+	if got.searchInput.Value() != "h" {
+		t.Fatalf("search input value = %q, want %q", got.searchInput.Value(), "h")
+	}
+	if got.searchMode != searchModeInsert {
+		t.Fatalf("search mode after typing = %v, want insert", got.searchMode)
+	}
+
+	updated, _ = got.updateLibraryMode(tea.KeyMsg{Type: tea.KeyEsc})
+	got = updated.(dashboardModel)
+	if got.searchMode != searchModeNormal {
+		t.Fatalf("search mode after esc = %v, want normal", got.searchMode)
+	}
+	if got.focus != focusSearchInput {
+		t.Fatalf("focus after esc = %v, want %v", got.focus, focusSearchInput)
+	}
+}
+
+func TestSubmitSearchSetsLoadingState(t *testing.T) {
+	m := newDashboardModel(nil)
+	m.searchInput.SetValue("dune")
+	m.searchQueryMode = model.SearchModeAuthor
+
+	cmd := m.submitSearch()
+	if cmd == nil {
+		t.Fatal("submitSearch() returned nil cmd for non-empty query")
+	}
+	if !m.loading || !m.searchLoading {
+		t.Fatalf("loading flags = loading:%v searchLoading:%v, want true/true", m.loading, m.searchLoading)
+	}
+	if m.searchLoadingQuery != "dune" {
+		t.Fatalf("searchLoadingQuery = %q, want dune", m.searchLoadingQuery)
+	}
+	if !strings.Contains(m.searchList.Title, "loading") {
+		t.Fatalf("search list title %q does not include loading state", m.searchList.Title)
+	}
+	if !strings.Contains(strings.ToLower(m.infoMsg), "searching for") {
+		t.Fatalf("info message %q does not include searching feedback", m.infoMsg)
+	}
+}
+
+func TestSubmitSearchGuardAndEmptyValidation(t *testing.T) {
+	m := newDashboardModel(nil)
+	m.searchLoading = true
+	m.searchInput.SetValue("dune")
+	if cmd := m.submitSearch(); cmd != nil {
+		t.Fatal("submitSearch() should return nil while search is already loading")
+	}
+
+	m.searchLoading = false
+	m.searchInput.SetValue("   ")
+	if cmd := m.submitSearch(); cmd != nil {
+		t.Fatal("submitSearch() should return nil for empty query")
+	}
+	if m.errMsg == "" {
+		t.Fatal("expected validation error for empty query")
+	}
+}
+
+func TestSearchLoadedMsgTransitionsToResults(t *testing.T) {
+	m := newDashboardModel(nil)
+	m.loading = true
+	m.searchLoading = true
+	m.focus = focusSearchInput
+
+	updated, _ := m.updateLibraryMode(searchLoadedMsg{
+		results: []model.SearchResult{{ID: 1, Title: "Dune"}},
+		query:   "dune",
+		mode:    model.SearchModeAuthor,
+	})
+	got := updated.(dashboardModel)
+
+	if got.loading || got.searchLoading {
+		t.Fatalf("loading flags after response = loading:%v searchLoading:%v, want false/false", got.loading, got.searchLoading)
+	}
+	if got.focus != focusSearchResults {
+		t.Fatalf("focus = %v, want %v", got.focus, focusSearchResults)
+	}
+	if got.lastQuery != "dune" {
+		t.Fatalf("lastQuery = %q, want dune", got.lastQuery)
+	}
+	if got.searchQueryMode != model.SearchModeAuthor {
+		t.Fatalf("searchQueryMode = %q, want %q", got.searchQueryMode, model.SearchModeAuthor)
+	}
+	if got.searchList.Title != "AUTHOR Results (1)" {
+		t.Fatalf("searchList title = %q, want %q", got.searchList.Title, "AUTHOR Results (1)")
+	}
+	if !strings.Contains(got.infoMsg, "loaded 1 results") {
+		t.Fatalf("info message = %q, expected loaded-count feedback", got.infoMsg)
+	}
+}

--- a/internal/model/search.go
+++ b/internal/model/search.go
@@ -1,0 +1,65 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SearchMode represents a discovery intent in search.
+type SearchMode string
+
+const (
+	SearchModeBook   SearchMode = "book"
+	SearchModeAuthor SearchMode = "author"
+	SearchModeGenre  SearchMode = "genre"
+)
+
+// ParseSearchMode parses a user-facing search mode value.
+func ParseSearchMode(raw string) (SearchMode, error) {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case "", "book", "books", "title":
+		return SearchModeBook, nil
+	case "author", "authors":
+		return SearchModeAuthor, nil
+	case "genre", "genres", "tag", "tags":
+		return SearchModeGenre, nil
+	default:
+		return "", fmt.Errorf("unknown search mode: %q (valid: book, author, genre)", raw)
+	}
+}
+
+// Label returns a compact uppercase label suitable for badges.
+func (m SearchMode) Label() string {
+	switch m {
+	case SearchModeAuthor:
+		return "AUTHOR"
+	case SearchModeGenre:
+		return "GENRE"
+	default:
+		return "BOOK"
+	}
+}
+
+// Description returns the applied discovery strategy.
+func (m SearchMode) Description() string {
+	switch m {
+	case SearchModeAuthor:
+		return "author-weighted"
+	case SearchModeGenre:
+		return "genre/tag-weighted"
+	default:
+		return "book-title weighted"
+	}
+}
+
+// Next cycles through modes in a deterministic order.
+func (m SearchMode) Next() SearchMode {
+	switch m {
+	case SearchModeBook:
+		return SearchModeAuthor
+	case SearchModeAuthor:
+		return SearchModeGenre
+	default:
+		return SearchModeBook
+	}
+}

--- a/internal/model/search_test.go
+++ b/internal/model/search_test.go
@@ -1,0 +1,42 @@
+package model
+
+import "testing"
+
+func TestParseSearchMode(t *testing.T) {
+	tests := []struct {
+		in   string
+		want SearchMode
+		ok   bool
+	}{
+		{"book", SearchModeBook, true},
+		{"author", SearchModeAuthor, true},
+		{"genre", SearchModeGenre, true},
+		{"tags", SearchModeGenre, true},
+		{"unknown", "", false},
+	}
+
+	for _, tt := range tests {
+		got, err := ParseSearchMode(tt.in)
+		if tt.ok && err != nil {
+			t.Fatalf("ParseSearchMode(%q) unexpected error: %v", tt.in, err)
+		}
+		if !tt.ok && err == nil {
+			t.Fatalf("ParseSearchMode(%q) expected error", tt.in)
+		}
+		if tt.ok && got != tt.want {
+			t.Fatalf("ParseSearchMode(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestSearchModeNext(t *testing.T) {
+	if SearchModeBook.Next() != SearchModeAuthor {
+		t.Fatal("book should cycle to author")
+	}
+	if SearchModeAuthor.Next() != SearchModeGenre {
+		t.Fatal("author should cycle to genre")
+	}
+	if SearchModeGenre.Next() != SearchModeBook {
+		t.Fatal("genre should cycle to book")
+	}
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends search to support intent modes (book/author/genre) by threading a new `model.SearchMode` from CLI/TUI down to the API GraphQL query, injecting `fields`/`weights` arguments and falling back to a minimal query on schema errors. It also adds output density controls (`--view compact|default|verbose`) that affect both CLI printing and TUI list/detail rendering, plus TUI UX improvements (mode badge, suggestions, quick +/- progress).

Test coverage is added for search mode parsing, query config selection, flexible numeric JSON decoding, and several TUI behaviors. One must-fix issue remains around `newDashboardModel(nil)` in tests: the model’s `Init()` path dereferences `m.app` via `loadLibraryCmd`, which will panic if any test triggers `Init()` on a nil-app model.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a must-fix nil-pointer panic risk in the TUI model initialization path (relevant to tests and future callers).
- Most changes are additive and well-covered by unit tests, and search-mode plumbing is consistent across CLI/TUI/app/api. Confidence is reduced due to the nil `*app.App` usage in tests combined with an `Init()` implementation that unconditionally dereferences the app in `loadLibraryCmd`, which is a clear panic footgun if `Init()` gets exercised.
- internal/cli/tui.go

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | README reorganized and updated to document new search modes and output density flags; no code-impacting issues. |
| internal/api/queries.go | SearchBooks now accepts SearchMode and injects fields/weights with schema-error fallback; needs verification of fallback error classification and query construction. |
| internal/api/queries_test.go | Adds unit test coverage for searchConfigForMode mappings across modes and unknown fallback. |
| internal/api/types_test.go | Adds tests for FlexibleInt and TypesenseResults JSON unmarshalling for mixed numeric formats. |
| internal/app/list_convert_test.go | Adds tests validating API->model conversion for extended book metrics and flexible time parsing, including invalid-time fallback behavior. |
| internal/app/search.go | App.SearchBooks signature updated to accept mode and default to book when empty; forwards to API layer. |
| internal/cli/output.go | Adds output density parsing and compact/verbose rendering for CLI list outputs, plus detail line formatting. |
| internal/cli/root.go | Adds persistent --view flag with validation in PersistentPreRunE for all commands. |
| internal/cli/search.go | CLI search now supports --mode parsing and passes SearchMode through app search call. |
| internal/cli/tui.go | TUI adds search mode switching, density cycling, suggestions, and quick progress; must verify key handling doesn’t break existing flows and app nil usage in tests is safe. |
| internal/cli/tui_test.go | Adds TUI behavior tests for vim-mode navigation, search submission/loading, and searchLoaded transitions. |
| internal/model/search.go | Adds SearchMode type with parsing, label/description, and cycling; logic is simple. |
| internal/model/search_test.go | Adds unit tests for ParseSearchMode and SearchMode.Next. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  autonumber
  participant User
  participant CLI as CLI (cobra)
  participant TUI as TUI Dashboard
  participant App
  participant API as API Client
  participant GraphQL as Hardcover GraphQL

  User->>CLI: "oku search <query> --mode <mode>"
  CLI->>App: "initApp()"
  CLI->>App: "SearchBooks(query, limit, mode)"
  App->>API: "SearchBooks(query, perPage, mode)"
  API->>API: "searchConfigForMode(mode)"
  API->>GraphQL: "search(query, per_page, page, fields, weights)"
  alt "schema rejects fields/weights"
    GraphQL-->>API: "schema error"
    API->>GraphQL: "search(query, per_page, page)"
  end
  GraphQL-->>API: "results (Typesense JSON)"
  API-->>App: "[]SearchResult"
  App-->>CLI: "[]SearchResult"
  CLI-->>User: "print (honor --json / --view)"

  User->>CLI: "oku" (interactive)
  CLI->>TUI: "runDashboard()"
  TUI->>App: "searchCmd -> SearchBooks(query, mode)"
  App->>API: "SearchBooks(query, perPage, mode)"
  API->>GraphQL: "search(...)"
  GraphQL-->>API: "results"
  API-->>TUI: "searchLoadedMsg(results, query, mode)"
  TUI-->>User: "render results + mode badge + suggestions"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->