### PR TITLE
udpate download section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binary
-oku
+/oku
 dist/
 
 # OS

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ Terminal companion for [Hardcover](https://hardcover.app): browse your shelves, 
 - Hardcover API token
 - Keychain support (recommended) or `HARDCOVER_TOKEN` env var
 
+## Install
+
+```bash
+go install github.com/Kameleon21/oku/cmd/oku@latest
+```
+
+If you are installing from an untagged branch:
+
+```bash
+go install github.com/Kameleon21/oku/cmd/oku@main
+```
+
 ## Quick Start
 
 ```bash

--- a/cmd/oku/main.go
+++ b/cmd/oku/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"os"
+
+	"github.com/Kameleon21/oku/internal/cli"
+)
+
+var version = "dev"
+
+func main() {
+	code := cli.Execute(version)
+	os.Exit(code)
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added proper `go install` support by creating the required `cmd/oku/main.go` entry point and updating documentation. This enables users to install the tool directly via `go install github.com/Kameleon21/oku/cmd/oku@latest` instead of having to clone and build manually.

- Created `cmd/oku/main.go` as the standard Go CLI entry point
- Added install section to README with instructions for both tagged and untagged installations
- Fixed `.gitignore` pattern from `oku` to `/oku` to properly ignore only the root binary

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are straightforward infrastructure improvements: adding a standard Go CLI entry point, updating documentation with install instructions, and fixing a gitignore pattern. All changes align with Go best practices and enable proper `go install` functionality.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .gitignore | Changed `oku` to `/oku` to properly ignore only the root binary, not all files named oku |
| README.md | Added install section with `go install` instructions for both tagged releases and untagged branches |
| cmd/oku/main.go | Created standard Go CLI entry point that calls `cli.Execute()` and exits with proper code |

</details>


</details>


<sub>Last reviewed commit: 19cfcb0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->