### PR TITLE
Fix: handle API token with or without Bearer prefix

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -65,10 +65,11 @@ func NewClient(token string) *Client {
 }
 
 // normalizeToken ensures the token carries the "Bearer " prefix required by the API.
+// It strips any existing bearer prefix (case-insensitive) before re-adding the canonical form.
 func normalizeToken(token string) string {
 	const prefix = "Bearer "
-	if strings.HasPrefix(token, prefix) {
-		return token
+	if strings.HasPrefix(strings.ToLower(token), "bearer ") {
+		return prefix + token[len("bearer "):]
 	}
 	return prefix + token
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -55,12 +55,22 @@ func IsNetworkError(err error) bool {
 }
 
 // NewClient creates a new Hardcover API client with the given auth token.
+// The token is normalised to include a "Bearer " prefix if missing.
 func NewClient(token string) *Client {
 	httpClient := &http.Client{Timeout: requestTimeout}
 	return &Client{
 		gql:   graphql.NewClient(endpoint, graphql.WithHTTPClient(httpClient)),
-		token: token,
+		token: normalizeToken(token),
 	}
+}
+
+// normalizeToken ensures the token carries the "Bearer " prefix required by the API.
+func normalizeToken(token string) string {
+	const prefix = "Bearer "
+	if strings.HasPrefix(token, prefix) {
+		return token
+	}
+	return prefix + token
 }
 
 // do executes a GraphQL request with auth header and rate limiting.

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,0 +1,41 @@
+package api
+
+import "testing"
+
+func TestNormalizeToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "already has Bearer prefix",
+			input: "Bearer abc123",
+			want:  "Bearer abc123",
+		},
+		{
+			name:  "raw token without prefix",
+			input: "abc123",
+			want:  "Bearer abc123",
+		},
+		{
+			name:  "lowercase bearer is not recognised",
+			input: "bearer abc123",
+			want:  "Bearer bearer abc123",
+		},
+		{
+			name:  "Bearer without space is not recognised",
+			input: "BearerNoSpace",
+			want:  "Bearer BearerNoSpace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeToken(tt.input)
+			if got != tt.want {
+				t.Fatalf("normalizeToken(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -19,12 +19,22 @@ func TestNormalizeToken(t *testing.T) {
 			want:  "Bearer abc123",
 		},
 		{
-			name:  "lowercase bearer is not recognised",
+			name:  "lowercase bearer is normalised",
 			input: "bearer abc123",
-			want:  "Bearer bearer abc123",
+			want:  "Bearer abc123",
 		},
 		{
-			name:  "Bearer without space is not recognised",
+			name:  "uppercase BEARER is normalised",
+			input: "BEARER abc123",
+			want:  "Bearer abc123",
+		},
+		{
+			name:  "mixed case Bearer is normalised",
+			input: "bEaReR abc123",
+			want:  "Bearer abc123",
+		},
+		{
+			name:  "Bearer without space is treated as raw token",
 			input: "BearerNoSpace",
 			want:  "Bearer BearerNoSpace",
 		},


### PR DESCRIPTION
## Summary

- Normalise the API token in `NewClient()` to always carry the canonical `Bearer ` prefix
- Strips any existing `bearer ` prefix (case-insensitive) before re-adding it, preventing malformed headers like `Bearer bearer abc123`
- Tokens without any prefix get `Bearer ` prepended automatically

## Test plan

- [x] Unit tests cover: correct prefix, raw token, lowercase `bearer`, uppercase `BEARER`, mixed case, and `Bearer` without trailing space
- [x] `go test ./...` passes
- [x] `go vet ./...` clean

Closes #12

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes API token handling by normalizing the Bearer prefix in `NewClient()`. The implementation strips any existing bearer prefix (case-insensitive) and re-adds the canonical `Bearer ` form, preventing malformed authorization headers.

**Key Changes:**
- Added `normalizeToken()` helper that ensures tokens always have the correct `Bearer ` prefix
- Handles raw tokens, lowercase/uppercase/mixed-case bearer prefixes correctly
- Added comprehensive unit tests covering all normalization scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and solves a real authentication issue. The logic correctly preserves the token value while normalizing the prefix, and comprehensive tests verify all edge cases
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/api/client.go | Added `normalizeToken` function to ensure Bearer prefix is always present and correctly formatted |
| internal/api/client_test.go | Comprehensive test coverage for token normalization including edge cases |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[Token from env/keychain] --> B[NewClient called]
    B --> C[normalizeToken]
    C --> D{Starts with bearer + space?}
    D -->|Yes| E[Strip existing prefix<br/>case-insensitive]
    D -->|No| F[Keep entire token]
    E --> G[Add canonical Bearer prefix]
    F --> G
    G --> H[Token stored in Client]
    H --> I[do method called]
    I --> J[Set authorization header<br/>with normalized token]
```

<sub>Last reviewed commit: 22309a3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->