### PR TITLE
ci: add release workflow, update goreleaser config, and document brew…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,48 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - main: ./cmd/oku
+    binary: oku
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+homebrew_casks:
+  - repository:
+      owner: Kameleon21
+      name: homebrew-oku
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    commit_author:
+      name: Kameleon21
+      email: kamilrogozinski29@gmail.com
+    directory: Casks
+    homepage: "https://github.com/Kameleon21/oku"
+    description: "A terminal companion for Hardcover — track your reading from the CLI"
+    skip_upload: auto
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"

--- a/README.md
+++ b/README.md
@@ -82,15 +82,15 @@ Use `--json` for JSON output and `--view compact|default|verbose` to control det
 
 Oku uses vim-style keybindings throughout. Arrow keys also work.
 
-| Key | Action |
-|-----|--------|
-| `h/l` | Move between panes |
-| `j/k` | Navigate lists |
-| `/` | Search |
+| Key     | Action                 |
+| ------- | ---------------------- |
+| `h/l`   | Move between panes     |
+| `j/k`   | Navigate lists         |
+| `/`     | Search                 |
 | `Enter` | Select / toggle status |
-| `+/-` | Quick page update |
-| `?` | Help |
-| `q` | Quit |
+| `+/-`   | Quick page update      |
+| `?`     | Help                   |
+| `q`     | Quit                   |
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,17 @@ Terminal companion for [Hardcover](https://hardcover.app): browse your shelves, 
 
 ## Install
 
-Stable release:
+macOS (Homebrew cask):
 
 ```bash
 brew tap Kameleon21/oku
 brew install --cask oku
 ```
 
-Go install (alternative):
+Linux / Windows:
+
+- Download a prebuilt binary from [GitHub Releases](https://github.com/Kameleon21/oku/releases/latest).
+- Or install from source with Go:
 
 ```bash
 go install github.com/Kameleon21/oku/cmd/oku@latest

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Terminal companion for [Hardcover](https://hardcover.app): browse your shelves, 
 Stable release:
 
 ```bash
+brew tap Kameleon21/oku
+brew install --cask oku
+```
+
+Go install (alternative):
+
+```bash
 go install github.com/Kameleon21/oku/cmd/oku@latest
 ```
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added CI/CD infrastructure for automated releases via GoReleaser and GitHub Actions, but contains a critical configuration error that will prevent releases from working.

- GitHub Actions workflow correctly triggers on version tags and uses GoReleaser with proper permissions
- GoReleaser config incorrectly uses `homebrew_casks` instead of `brews` - casks are for macOS GUI applications (`.app` bundles), not CLI binaries
- README documentation reflects the incorrect cask installation method (`brew install --cask oku` should be `brew install oku`)
- The `directory` field should be `Formula` not `Casks` for Homebrew formulas
- Once corrected, this will enable users to install via Homebrew tap and automate multi-platform releases

<h3>Confidence Score: 1/5</h3>

- This PR will fail to release due to incorrect Homebrew configuration
- The core issue is a misunderstanding of Homebrew packaging - using `homebrew_casks` for a CLI tool will cause GoReleaser to fail since casks require macOS `.app` bundles, not standalone binaries. This needs to be changed to `brews` before merging.
- `.goreleaser.yaml` requires critical fix from casks to brews, `README.md` needs installation command corrected

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Added GitHub Actions workflow to automate releases with GoReleaser on tag push - configuration looks correct |
| .goreleaser.yaml | Added GoReleaser config, but uses `homebrew_casks` instead of `brews` - will fail for CLI tool |
| README.md | Updated installation instructions with Homebrew, but uses incorrect `--cask` flag for CLI tool |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer pushes tag v*] --> B[GitHub Actions: Release workflow triggers]
    B --> C[Checkout code with full history]
    C --> D[Set up Go from go.mod]
    D --> E[Run GoReleaser]
    E --> F[Execute: go mod tidy]
    F --> G[Build binaries for darwin/linux/windows]
    G --> H[Create archives: tar.gz / zip]
    H --> I{homebrew_casks config}
    I --> J[ERROR: Casks require .app bundles]
    I -.Should be.-> K[brews: Push Formula to homebrew-oku]
    K --> L[Users: brew install oku]
    J --> M[Release fails]
```

<sub>Last reviewed commit: 7e4fb90</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->