### PR TITLE
Fix TUI startup delay

### DIFF
--- a/internal/app/list.go
+++ b/internal/app/list.go
@@ -42,6 +42,21 @@ func (a *App) ListBooks(ctx context.Context, status model.Status, refresh bool) 
 	return books, err
 }
 
+// ListCachedBooks returns locally cached books and reports whether the cache
+// should be refreshed. It never performs a network request.
+func (a *App) ListCachedBooks(status model.Status) ([]model.UserBook, bool, error) {
+	books, err := a.Store.ListUserBooks(status)
+	if err != nil {
+		return nil, false, err
+	}
+
+	stale, err := a.isStatusCacheStale(status)
+	if err != nil {
+		return nil, false, err
+	}
+	return books, len(books) == 0 || stale, nil
+}
+
 func (a *App) isStatusCacheStale(status model.Status) (bool, error) {
 	val, err := a.Store.GetState(syncStateKey(status))
 	if err != nil {

--- a/internal/app/list_test.go
+++ b/internal/app/list_test.go
@@ -1,0 +1,38 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Kameleon21/oku/internal/model"
+)
+
+func TestListCachedBooksReportsRefreshState(t *testing.T) {
+	a := newTestApp(t)
+	upsertBookWithStatus(t, a, 1, 11, model.StatusCurrentlyReading, "Dune")
+
+	books, needsRefresh, err := a.ListCachedBooks(model.StatusCurrentlyReading)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(books) != 1 || books[0].Book.Title != "Dune" {
+		t.Fatalf("ListCachedBooks() = %#v, want Dune", books)
+	}
+	if !needsRefresh {
+		t.Fatal("cache without sync state should need refresh")
+	}
+
+	if err := a.Store.SetState(
+		syncStateKey(model.StatusCurrentlyReading),
+		time.Now().UTC().Format(time.RFC3339),
+	); err != nil {
+		t.Fatal(err)
+	}
+	_, needsRefresh, err = a.ListCachedBooks(model.StatusCurrentlyReading)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if needsRefresh {
+		t.Fatal("recently synced cache should not need refresh")
+	}
+}

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -167,9 +167,10 @@ func (i searchResultItem) FilterValue() string {
 // ── Messages ───────────────────────────────────────────────────────────────
 
 type libraryLoadedMsg struct {
-	reading []model.UserBook
-	oku     []model.UserBook
-	err     error
+	reading      []model.UserBook
+	oku          []model.UserBook
+	needsRefresh bool
+	err          error
 }
 
 type searchLoadedMsg struct {
@@ -370,7 +371,7 @@ func newDashboardModel(a *app.App) dashboardModel {
 func (m dashboardModel) Init() tea.Cmd {
 	return tea.Batch(
 		m.spin.Tick,
-		loadLibraryCmd(m.app, false),
+		loadCachedLibraryCmd(m.app),
 		loadLocalDataCmd(m.app),
 		backgroundCheckCmd(),
 		timerTickCmd(),
@@ -420,6 +421,10 @@ func (m dashboardModel) updateLibraryMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.refreshListItems()
 		m.updateSearchSuggestions()
 		m.errMsg = ""
+		if msg.needsRefresh {
+			m.loading = true
+			return m, loadLibraryCmd(m.app, true)
+		}
 		return m, nil
 
 	case localDataLoadedMsg:
@@ -2040,6 +2045,27 @@ func (m dashboardModel) changeSelectedSearchStatus(status model.Status) (tea.Mod
 }
 
 // ── Tea Commands ───────────────────────────────────────────────────────────
+
+func loadCachedLibraryCmd(a *app.App) tea.Cmd {
+	return func() tea.Msg {
+		if a == nil {
+			return libraryLoadedMsg{err: fmt.Errorf("dashboard app is not initialized")}
+		}
+		reading, readingStale, err := a.ListCachedBooks(model.StatusCurrentlyReading)
+		if err != nil {
+			return libraryLoadedMsg{err: err}
+		}
+		oku, okuStale, err := a.ListCachedBooks(model.StatusWantToRead)
+		if err != nil {
+			return libraryLoadedMsg{err: err}
+		}
+		return libraryLoadedMsg{
+			reading:      reading,
+			oku:          oku,
+			needsRefresh: readingStale || okuStale,
+		}
+	}
+}
 
 func loadLibraryCmd(a *app.App, refresh bool) tea.Cmd {
 	return func() tea.Msg {

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -51,6 +51,44 @@ func TestLoadLibraryCmdWithNilAppReturnsError(t *testing.T) {
 	}
 }
 
+func TestLoadCachedLibraryCmdWithNilAppReturnsError(t *testing.T) {
+	cmd := loadCachedLibraryCmd(nil)
+	if cmd == nil {
+		t.Fatal("loadCachedLibraryCmd() returned nil cmd")
+	}
+
+	msg := cmd()
+	loaded, ok := msg.(libraryLoadedMsg)
+	if !ok {
+		t.Fatalf("loadCachedLibraryCmd() msg type = %T, want libraryLoadedMsg", msg)
+	}
+	if loaded.err == nil {
+		t.Fatal("expected libraryLoadedMsg error for nil app")
+	}
+}
+
+func TestStaleCachedLibraryRendersBeforeRefresh(t *testing.T) {
+	m := newDashboardModel(nil)
+	updated, cmd := m.updateLibraryMode(libraryLoadedMsg{
+		reading:      []model.UserBook{{Book: model.Book{ID: 1, Title: "Dune"}}},
+		needsRefresh: true,
+	})
+	got := updated.(dashboardModel)
+
+	if !got.loaded {
+		t.Fatal("cached library should mark dashboard loaded")
+	}
+	if !got.loading {
+		t.Fatal("stale cache should start a background refresh")
+	}
+	if len(got.readingBooks) != 1 || got.readingBooks[0].Book.Title != "Dune" {
+		t.Fatalf("cached reading books = %#v, want Dune", got.readingBooks)
+	}
+	if cmd == nil {
+		t.Fatal("stale cache should return a refresh command")
+	}
+}
+
 func TestSearchInputInsertModeTypingAndEsc(t *testing.T) {
 	m := newDashboardModel(nil)
 	m.section = sectionSearch


### PR DESCRIPTION
## Summary
- render cached reading lists before refreshing stale data
- refresh stale library data in the background
- cover cache freshness and TUI transition behavior with tests

## Verification
- `go test ./...`
- `go build ./cmd/oku`
- `goreleaser release --snapshot --clean`