### PR TITLE
fix: address medium-severity code review findings 11-20

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -17,6 +17,7 @@ const endpoint = "https://api.hardcover.app/v1/graphql"
 
 const (
 	requestTimeout = 30 * time.Second
+	attemptTimeout = 10 * time.Second
 	maxRetries     = 3
 )
 
@@ -88,7 +89,7 @@ func NewClient(token string) *Client {
 
 func newClientWithEndpoint(url, token string) *Client {
 	httpClient := &http.Client{
-		Timeout:   requestTimeout,
+		Timeout:   attemptTimeout,
 		Transport: &statusTransport{base: http.DefaultTransport},
 	}
 	return &Client{
@@ -138,6 +139,9 @@ func (c *Client) do(ctx context.Context, req *graphql.Request, resp interface{})
 		backoff := time.Duration(attempt*attempt) * 200 * time.Millisecond
 		select {
 		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return ctx.Err()
+			}
 			return &NetworkError{Err: ctx.Err()}
 		case <-time.After(backoff):
 		}

--- a/internal/api/queries.go
+++ b/internal/api/queries.go
@@ -11,6 +11,13 @@ import (
 	"github.com/machinebox/graphql"
 )
 
+// AuthError reports that the API response did not contain an authenticated user.
+type AuthError struct{}
+
+func (e *AuthError) Error() string {
+	return "authentication failed: run `oku auth set-token` or check your Hardcover token"
+}
+
 // GetMe returns the authenticated user's ID and username.
 func (c *Client) GetMe(ctx context.Context) (int, string, error) {
 	req := graphql.NewRequest(`query { me { id, username } }`)
@@ -20,7 +27,7 @@ func (c *Client) GetMe(ctx context.Context) (int, string, error) {
 		return 0, "", fmt.Errorf("GetMe: %w", err)
 	}
 	if len(resp.Me) == 0 {
-		return 0, "", fmt.Errorf("GetMe: empty response")
+		return 0, "", fmt.Errorf("GetMe: %w", &AuthError{})
 	}
 
 	return resp.Me[0].ID, resp.Me[0].Username, nil
@@ -46,7 +53,7 @@ func (c *Client) ListUserBooks(ctx context.Context, statusID int) ([]APIUserBook
 		}
 	}
 	if len(resp.Me) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("ListUserBooks: %w", &AuthError{})
 	}
 
 	return resp.Me[0].UserBooks, nil

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -82,9 +83,32 @@ type SearchResponse struct {
 
 // TypesenseResults represents parsed Typesense search results.
 type TypesenseResults struct {
-	Hits []struct {
-		Document TypesenseBookDoc `json:"document"`
-	} `json:"hits"`
+	Hits []TypesenseHit `json:"hits"`
+}
+
+// TypesenseHit represents one search hit.
+type TypesenseHit struct {
+	Document TypesenseBookDoc `json:"document"`
+}
+
+// UnmarshalJSON skips malformed individual hits while retaining valid results.
+func (r *TypesenseResults) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Hits []json.RawMessage `json:"hits"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	r.Hits = make([]TypesenseHit, 0, len(raw.Hits))
+	for _, rawHit := range raw.Hits {
+		var hit TypesenseHit
+		if err := json.Unmarshal(rawHit, &hit); err != nil {
+			continue
+		}
+		r.Hits = append(r.Hits, hit)
+	}
+	return nil
 }
 
 // TypesenseBookDoc represents a book document from Typesense search.
@@ -124,7 +148,7 @@ func (v *FlexibleInt) UnmarshalJSON(data []byte) error {
 			*v = 0
 			return nil
 		}
-		n, err := strconv.Atoi(unquoted)
+		n, err := parseFlexibleInt(unquoted)
 		if err != nil {
 			return fmt.Errorf("parse quoted number %q: %w", unquoted, err)
 		}
@@ -133,12 +157,24 @@ func (v *FlexibleInt) UnmarshalJSON(data []byte) error {
 	}
 
 	// Raw number: 123
-	n, err := strconv.Atoi(s)
+	n, err := parseFlexibleInt(s)
 	if err != nil {
 		return fmt.Errorf("parse number %q: %w", s, err)
 	}
 	*v = FlexibleInt(n)
 	return nil
+}
+
+func parseFlexibleInt(s string) (int, error) {
+	n, err := strconv.Atoi(s)
+	if err == nil {
+		return n, nil
+	}
+	f, floatErr := strconv.ParseFloat(s, 64)
+	if floatErr != nil || math.IsNaN(f) || math.IsInf(f, 0) || f < math.MinInt32 || f > math.MaxInt32 {
+		return 0, err
+	}
+	return int(f), nil
 }
 
 // FlexibleFloat handles APIs that may return a number or a quoted number.

--- a/internal/api/types_test.go
+++ b/internal/api/types_test.go
@@ -14,6 +14,11 @@ func TestFlexibleIntUnmarshalJSON(t *testing.T) {
 	}{
 		{name: "number", in: `123`, want: 123},
 		{name: "quoted number", in: `"456"`, want: 456},
+		{name: "float", in: `412.9`, want: 412},
+		{name: "quoted float", in: `"412.9"`, want: 412},
+		{name: "NaN", in: `"NaN"`, wantErr: true},
+		{name: "Inf", in: `"Inf"`, wantErr: true},
+		{name: "huge exponent", in: `1e300`, wantErr: true},
 		{name: "null", in: `null`, want: 0},
 		{name: "quoted empty", in: `""`, want: 0},
 		{name: "invalid", in: `"abc"`, wantErr: true},
@@ -36,6 +41,21 @@ func TestFlexibleIntUnmarshalJSON(t *testing.T) {
 				t.Fatalf("value = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestTypesenseResultsSkipsMalformedHit(t *testing.T) {
+	raw := []byte(`{"hits":[
+  {"document":{"id":"bad","title":"Broken"}},
+  {"document":{"id":202,"title":"Foundation","pages":255}}
+]}`)
+
+	var results TypesenseResults
+	if err := json.Unmarshal(raw, &results); err != nil {
+		t.Fatalf("unmarshal typesense results: %v", err)
+	}
+	if len(results.Hits) != 1 || results.Hits[0].Document.ID != 202 {
+		t.Fatalf("hits = %+v, want only valid hit 202", results.Hits)
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -121,7 +121,11 @@ func (a *App) GetActiveBooks() ([]model.UserBook, error) {
 		if err != nil {
 			return nil, err
 		}
-		if ub == nil || ub.StatusID != model.StatusCurrentlyReading {
+		if ub == nil {
+			validIDs = append(validIDs, id)
+			continue
+		}
+		if ub.StatusID != model.StatusCurrentlyReading {
 			continue
 		}
 		books = append(books, *ub)

--- a/internal/app/app_active_test.go
+++ b/internal/app/app_active_test.go
@@ -136,6 +136,29 @@ func TestGetActiveBookIDFallsBackToSingleActiveEntry(t *testing.T) {
 	}
 }
 
+func TestGetActiveBooksKeepsUnknownID(t *testing.T) {
+	a := newTestApp(t)
+	if err := a.AddActiveBook(42); err != nil {
+		t.Fatal(err)
+	}
+
+	books, err := a.GetActiveBooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(books) != 0 {
+		t.Fatalf("GetActiveBooks() = %v, want no cached books", books)
+	}
+
+	ids, err := a.GetActiveBookIDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(ids, []int{42}) {
+		t.Fatalf("GetActiveBookIDs() = %v, want unknown ID preserved", ids)
+	}
+}
+
 func TestRemoveActiveBookLeavesSingleDefault(t *testing.T) {
 	a := newTestApp(t)
 	upsertReadingBook(t, a, 100, 1, "Book One")

--- a/internal/app/timer.go
+++ b/internal/app/timer.go
@@ -111,8 +111,8 @@ func (a *App) TimerList(limit int) ([]model.ReadingSession, error) {
 // GetStreak computes the current, longest, and total reading streak from session data.
 func (a *App) GetStreak() (*model.StreakInfo, error) {
 	// Get all daily activity from the beginning of time.
-	from := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	to := time.Now().UTC()
+	from := time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local)
+	to := time.Now().In(time.Local)
 	activities, err := a.Store.GetDailyActivity(from, to)
 	if err != nil {
 		return nil, err

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -30,6 +30,7 @@ func (a *App) UpdateProgress(ctx context.Context, bookID int, pageUpdate model.P
 	if err != nil {
 		return 0, err
 	}
+	latestRead = unfinishedRead(latestRead)
 	if latestRead != nil {
 		currentPage = latestRead.ProgressPages
 	}
@@ -73,4 +74,11 @@ func (a *App) UpdateProgress(ctx context.Context, bookID int, pageUpdate model.P
 	}
 
 	return newPage, nil
+}
+
+func unfinishedRead(read *model.UserBookRead) *model.UserBookRead {
+	if read != nil && read.FinishedAt == nil {
+		return read
+	}
+	return nil
 }

--- a/internal/app/update_test.go
+++ b/internal/app/update_test.go
@@ -1,0 +1,21 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Kameleon21/oku/internal/model"
+)
+
+func TestUnfinishedReadRejectsFinishedRead(t *testing.T) {
+	finishedAt := time.Now()
+	finished := &model.UserBookRead{ID: 1, ProgressPages: 300, FinishedAt: &finishedAt}
+	if got := unfinishedRead(finished); got != nil {
+		t.Fatalf("unfinishedRead(finished) = %+v, want nil so UpdateProgress creates a new read", got)
+	}
+
+	active := &model.UserBookRead{ID: 2, ProgressPages: 50}
+	if got := unfinishedRead(active); got != active {
+		t.Fatalf("unfinishedRead(active) = %+v, want original read", got)
+	}
+}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -25,6 +26,9 @@ func GetToken() (string, error) {
 	token, err := keyring.Get(serviceName, accountName)
 	if err == nil && token != "" {
 		return token, nil
+	}
+	if err != nil && !errors.Is(err, keyring.ErrNotFound) {
+		return "", fmt.Errorf("keyring backend unavailable: %w; set %s as a workaround", err, envKey)
 	}
 
 	return "", fmt.Errorf("no API token found. Set %s or run: oku auth set-token", envKey)

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -240,9 +240,10 @@ type dashboardModel struct {
 	dirty            bool
 	lastMutationAt   time.Time
 
-	lastQuery string
-	infoMsg   string
-	errMsg    string
+	lastQuery      string
+	lastSearchMode model.SearchMode
+	infoMsg        string
+	errMsg         string
 
 	searchLoading      bool
 	searchLoadingQuery string
@@ -466,6 +467,7 @@ func (m dashboardModel) updateLibraryMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.searchQueryMode = msg.mode
 		m.lastQuery = msg.query
+		m.lastSearchMode = msg.mode
 		m.searchBooks = msg.results
 		m.refreshSearchResultItems()
 		m.searchList.Title = fmt.Sprintf("%s Results (%d)", m.searchQueryMode.Label(), len(msg.results))
@@ -1730,7 +1732,8 @@ func (m *dashboardModel) submitSearch() tea.Cmd {
 	}
 
 	// Reuse in-memory results for the same query instead of refetching.
-	if strings.EqualFold(query, strings.TrimSpace(m.lastQuery)) && len(m.searchList.Items()) > 0 {
+	if strings.EqualFold(query, strings.TrimSpace(m.lastQuery)) &&
+		m.searchQueryMode == m.lastSearchMode && len(m.searchList.Items()) > 0 {
 		m.searchSub = searchSubResults
 		m.searchMode = searchModeNormal
 		m.searchInput.Blur()

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -16,16 +16,22 @@ type Store struct {
 // New opens (or creates) the SQLite database at dbPath, runs migrations,
 // and returns a ready-to-use Store.
 func New(dbPath string) (*Store, error) {
-	db, err := sql.Open("sqlite", dbPath)
+	separator := "?"
+	if strings.Contains(dbPath, "?") {
+		separator = "&"
+	}
+	dsn := dbPath + separator + "_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}
 
-	// Enable WAL mode and foreign keys for better concurrent access.
-	for _, pragma := range []string{
-		"PRAGMA journal_mode=WAL",
-		"PRAGMA foreign_keys=ON",
-	} {
+	// NOTE: do not SetMaxOpenConns(1) — several queries (e.g. ListUserBooks →
+	// GetLatestRead) run while iterating another query's rows, which deadlocks
+	// on a single-connection pool. busy_timeout above handles writer contention.
+
+	// Enable WAL mode for better concurrent access.
+	for _, pragma := range []string{"PRAGMA journal_mode=WAL"} {
 		if _, err := db.Exec(pragma); err != nil {
 			db.Close()
 			return nil, fmt.Errorf("exec %s: %w", pragma, err)

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -80,15 +80,15 @@ LIMIT ?
 // Only completed sessions (ended_at IS NOT NULL) are counted.
 func (s *Store) GetDailyActivity(from, to time.Time) ([]model.DayActivity, error) {
 	const query = `
-SELECT date(started_at) as day,
+SELECT date(started_at, 'localtime') as day,
        SUM(
            CAST((julianday(ended_at) - julianday(started_at)) * 1440 AS INTEGER)
        ) as minutes
 FROM reading_sessions
 WHERE ended_at IS NOT NULL
-  AND date(started_at) >= date(?)
-  AND date(started_at) <= date(?)
-GROUP BY date(started_at)
+  AND date(started_at, 'localtime') >= date(?)
+  AND date(started_at, 'localtime') <= date(?)
+GROUP BY date(started_at, 'localtime')
 ORDER BY day
 `
 	fromStr := from.Format("2006-01-02")
@@ -107,7 +107,7 @@ ORDER BY day
 		if err := rows.Scan(&dayStr, &minutes); err != nil {
 			return nil, fmt.Errorf("scan daily activity: %w", err)
 		}
-		if t, err := time.Parse("2006-01-02", dayStr); err == nil {
+		if t, err := time.ParseInLocation("2006-01-02", dayStr, time.Local); err == nil {
 			if minutes < 0 {
 				minutes = 0
 			}
@@ -123,8 +123,8 @@ func (s *Store) GetWeeklyStats(from, to time.Time) (model.WeeklyStats, error) {
 SELECT started_at, ended_at
 FROM reading_sessions
 WHERE ended_at IS NOT NULL
-  AND date(started_at) >= date(?)
-  AND date(started_at) <= date(?)
+  AND date(started_at, 'localtime') >= date(?)
+  AND date(started_at, 'localtime') <= date(?)
 ORDER BY started_at
 `
 	fromStr := from.Format("2006-01-02")
@@ -156,7 +156,7 @@ ORDER BY started_at
 
 		// time.Weekday: Sun=0, Mon=1, ..., Sat=6
 		// We want Mon=0, ..., Sun=6
-		dayIdx := (int(startTime.Weekday()) + 6) % 7
+		dayIdx := (int(startTime.In(time.Local).Weekday()) + 6) % 7
 		stats.Days[dayIdx] += minutes
 		stats.Total += minutes
 		stats.Sessions++


### PR DESCRIPTION
Fixes the ten medium-severity findings (11–20) from `tasks/code-review-2026-07-11.md`.

## Changes

| # | Finding | Fix |
|---|---------|-----|
| 11 | Retry-on-timeout could never fire | 10s per-attempt HTTP timeout under the 30s overall context budget (`api/client.go`) |
| 12 | Ctrl+C during backoff misclassified | bare `context.Canceled` returned instead of wrapping in `NetworkError` |
| 13 | `UpdateProgress` corrupted finished reads | finished reads (`FinishedAt != nil`) are no longer reused; a new read starts instead |
| 14 | Streaks/heatmap bucketed in UTC | local-date bucketing via SQLite `'localtime'` modifier + `ParseInLocation` (`app/timer.go`, `store/sessions.go`) |
| 15 | `GetActiveBooks` pruned unknown IDs | IDs missing from the local cache are kept; only wrong-status entries are pruned |
| 16 | `foreign_keys` pragma per-connection/dead | `foreign_keys` + `busy_timeout(5000)` moved into the DSN so every connection gets them |
| 17 | Keyring backend errors read as "no token" | broken backend reported distinctly from `keyring.ErrNotFound`, with env-var workaround hint |
| 18 | Bad token → silent empty library | typed `AuthError` with a `oku auth set-token` hint from `GetMe`/`ListUserBooks` |
| 19 | `FlexibleInt` rejected floats; one bad hit killed search | float fallback (NaN/Inf/overflow guarded); malformed hits skipped individually |
| 20 | Cached search results ignored mode | in-memory result reuse now requires query **and** search mode to match |

## Notes

- `SetMaxOpenConns(1)` (floated in finding 16) was tried and **reverted**: `ListUserBooks` runs `GetLatestRead` while iterating its own rows, which deadlocks a single-connection pool (test suite hung; goroutine dump confirmed). A comment in `db.go` documents the trap.
- Known tradeoffs accepted, documented in `tasks/todo.md`: timed-out non-idempotent mutations may now be retried (needs idempotency keys to fix properly); requests legitimately slower than 10s fail all attempts; phantom active-book IDs are never auto-pruned.

## Verification

`go build ./...`, `gofmt -l .`, `go vet ./...`, `go test ./...` all clean. New tests: float/NaN/Inf `FlexibleInt` cases, malformed-hit skipping, unknown-active-ID preservation, finished-read rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)